### PR TITLE
Convenience method for checking header value lists

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -238,7 +238,7 @@ public interface ClientRequestContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+    public default boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
         return containsHeaderString(name, ",", valuePredicate);
     }
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -193,6 +193,23 @@ public interface ClientRequestContext {
     public String getHeaderString(String name);
 
     /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * @param name the message header.
+     * @param value the message header value.
+     * @param ignoreCase whether to ignore upper/lower case.
+     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
+     * comma-separated header string contains value as a whole word.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     */
+    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+
+    /**
      * Get message date.
      *
      * @return the message date, otherwise {@code null} if not present.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -194,7 +194,7 @@ public interface ClientRequestContext {
     public String getHeaderString(String name);
 
     /**
-     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.
      *
      * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
@@ -210,12 +210,37 @@ public interface ClientRequestContext {
      * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
-     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * matching the predicate, or having at least one whitespace-trimmed single value in a token-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
     public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
+
+    /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
+     * @param name the message header.
+     * @param valuePredicate value must fulfil this predicate.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     * @since 4.0
+     */
+    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+        return containsHeaderString(name, ",", valuePredicate);
+    }
 
     /**
      * Get message date.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -202,8 +202,8 @@ public interface ClientRequestContext {
      *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
-     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
-     * comma-separated header string contains value as a whole word.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -200,6 +200,12 @@ public interface ClientRequestContext {
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -201,13 +201,13 @@ public interface ClientRequestContext {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
-     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
+     * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -201,12 +201,13 @@ public interface ClientRequestContext {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
+     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
@@ -214,7 +215,7 @@ public interface ClientRequestContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
+    public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
 
     /**
      * Get message date.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.Cookie;
@@ -200,15 +201,14 @@ public interface ClientRequestContext {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the message header.
-     * @param value the message header value.
-     * @param ignoreCase whether to ignore upper/lower case.
+     * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
 
     /**
      * Get message date.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -206,6 +206,7 @@ public interface ClientRequestContext {
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
+     * @since 4.0
      */
     public boolean containsHeaderString(String name, String value, boolean ignoreCase);
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -180,7 +180,7 @@ public interface ClientRequestContext {
     /**
      * Get a message header as a single string value.
      *
-     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
@@ -196,7 +196,7 @@ public interface ClientRequestContext {
     /**
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
-     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -93,12 +93,13 @@ public interface ClientResponseContext {
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
+     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
@@ -106,7 +107,7 @@ public interface ClientResponseContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
+    public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.Link;
@@ -92,15 +93,14 @@ public interface ClientResponseContext {
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
      * @param name the message header.
-     * @param value the message header value.
-     * @param ignoreCase whether to ignore upper/lower case.
+     * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -92,6 +92,12 @@ public interface ClientResponseContext {
     /**
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -89,6 +89,19 @@ public interface ClientResponseContext {
     public String getHeaderString(String name);
 
     /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * @param name the message header.
+     * @param value the message header value.
+     * @param ignoreCase whether to ignore upper/lower case.
+     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
+     * comma-separated header string contains value as a whole word.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     */
+    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+
+    /**
      * Get the allowed HTTP methods from the Allow HTTP header.
      *
      * @return the allowed HTTP methods, all methods will returned as upper case strings.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -126,7 +126,7 @@ public interface ClientResponseContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+    public default boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
         return containsHeaderString(name, ",", valuePredicate);
     }
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -93,13 +93,13 @@ public interface ClientResponseContext {
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
-     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
+     * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -94,8 +94,8 @@ public interface ClientResponseContext {
      *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
-     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
-     * comma-separated header string contains value as a whole word.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -98,6 +98,7 @@ public interface ClientResponseContext {
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
+     * @since 4.0
      */
     public boolean containsHeaderString(String name, String value, boolean ignoreCase);
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -90,7 +90,7 @@ public interface ClientResponseContext {
     public String getHeaderString(String name);
 
     /**
-     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.
      *
      * <p>
      * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
@@ -102,12 +102,33 @@ public interface ClientResponseContext {
      * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
-     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * matching the predicate, or having at least one whitespace-trimmed single value in a token-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
     public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
+
+    /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
+     * @param name the message header.
+     * @param valuePredicate value must fulfil this predicate.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     * @since 4.0
+     */
+    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+        return containsHeaderString(name, ",", valuePredicate);
+    }
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.MediaType;
@@ -232,15 +233,14 @@ public interface ContainerRequestContext {
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
      * @param name the message header.
-     * @param value the message header value.
-     * @param ignoreCase whether to ignore upper/lower case.
+     * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
 
     /**
      * Get message date.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -229,6 +229,19 @@ public interface ContainerRequestContext {
     public String getHeaderString(String name);
 
     /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * @param name the message header.
+     * @param value the message header value.
+     * @param ignoreCase whether to ignore upper/lower case.
+     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
+     * comma-separated header string contains value as a whole word.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     */
+    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+
+    /**
      * Get message date.
      *
      * @return the message date, otherwise {@code null} if not present.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -230,7 +230,7 @@ public interface ContainerRequestContext {
     public String getHeaderString(String name);
 
     /**
-     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.
      *
      * <p>
      * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
@@ -242,12 +242,33 @@ public interface ContainerRequestContext {
      * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
-     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * matching the predicate, or having at least one whitespace-trimmed single value in a token-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
     public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
+
+    /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
+     * @param name the message header.
+     * @param valuePredicate value must fulfil this predicate.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     * @since 4.0
+     */
+    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+        return containsHeaderString(name, ",", valuePredicate);
+    }
 
     /**
      * Get message date.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -238,6 +238,7 @@ public interface ContainerRequestContext {
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
+     * @since 4.0
      */
     public boolean containsHeaderString(String name, String value, boolean ignoreCase);
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -233,12 +233,13 @@ public interface ContainerRequestContext {
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
+     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
@@ -246,7 +247,7 @@ public interface ContainerRequestContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
+    public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
 
     /**
      * Get message date.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -266,7 +266,7 @@ public interface ContainerRequestContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+    public default boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
         return containsHeaderString(name, ",", valuePredicate);
     }
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -232,6 +232,12 @@ public interface ContainerRequestContext {
     /**
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -233,13 +233,13 @@ public interface ContainerRequestContext {
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
-     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
+     * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -234,8 +234,8 @@ public interface ContainerRequestContext {
      *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
-     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
-     * comma-separated header string contains value as a whole word.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -115,6 +115,22 @@ public interface ContainerResponseContext {
     public String getHeaderString(String name);
 
     /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * @param name the message header.
+     * @param value the message header value.
+     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
+     * comma-separated header string contains value as a whole word.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     */
+    public boolean containsHeaderValue(String name, String value);
+
+    /**
      * Get the allowed HTTP methods from the Allow HTTP header.
      *
      * @return the allowed HTTP methods, all methods will returned as upper case strings.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -160,7 +160,7 @@ public interface ContainerResponseContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+    public default boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
         return containsHeaderString(name, ",", valuePredicate);
     }
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -116,7 +116,7 @@ public interface ContainerResponseContext {
     public String getHeaderString(String name);
 
     /**
-     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.
      *
      * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
@@ -132,12 +132,37 @@ public interface ContainerResponseContext {
      * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
-     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * matching the predicate, or having at least one whitespace-trimmed single value in a token-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
     public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
+
+    /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
+     * @param name the message header.
+     * @param valuePredicate value must fulfil this predicate.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * @see #getHeaders()
+     * @see #getHeaderString(String)
+     * @since 4.0
+     */
+    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+        return containsHeaderString(name, ",", valuePredicate);
+    }
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.Link;
@@ -122,15 +123,14 @@ public interface ContainerResponseContext {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the message header.
-     * @param value the message header value.
-     * @param ignoreCase whether to ignore upper/lower case.
+     * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -123,12 +123,13 @@ public interface ContainerResponseContext {
      *
      * @param name the message header.
      * @param value the message header value.
+     * @param ignoreCase whether to ignore upper/lower case.
      * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      */
-    public boolean containsHeaderValue(String name, String value);
+    public boolean containsHeaderValue(String name, String value, boolean ignoreCase);
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -123,12 +123,13 @@ public interface ContainerResponseContext {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
+     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
@@ -136,7 +137,7 @@ public interface ContainerResponseContext {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
+    public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -102,7 +102,7 @@ public interface ContainerResponseContext {
     /**
      * Get a message header as a single string value.
      *
-     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
@@ -118,7 +118,7 @@ public interface ContainerResponseContext {
     /**
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
-     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -122,6 +122,12 @@ public interface ContainerResponseContext {
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -128,6 +128,7 @@ public interface ContainerResponseContext {
      * comma-separated header string contains value as a whole word.
      * @see #getHeaders()
      * @see #getHeaderString(String)
+     * @since 4.0
      */
     public boolean containsHeaderString(String name, String value, boolean ignoreCase);
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -123,13 +123,13 @@ public interface ContainerResponseContext {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
-     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
+     * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -124,8 +124,8 @@ public interface ContainerResponseContext {
      *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
-     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
-     * comma-separated header string contains value as a whole word.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
      * @see #getHeaders()
      * @see #getHeaderString(String)
      * @since 4.0

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -129,7 +129,7 @@ public interface ContainerResponseContext {
      * @see #getHeaders()
      * @see #getHeaderString(String)
      */
-    public boolean containsHeaderValue(String name, String value, boolean ignoreCase);
+    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
 
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -74,6 +74,7 @@ public interface HttpHeaders {
      * comma-separated header string contains value as a whole word.
      * @see #getRequestHeaders()
      * @see #getHeaderString(String)
+     * @since 4.0
      */
     public boolean containsHeaderString(String name, String value, boolean ignoreCase);
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -69,12 +69,13 @@ public interface HttpHeaders {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
+     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
@@ -82,7 +83,7 @@ public interface HttpHeaders {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
+    public boolean containsHeaderString(String name, String valuleSeparatorRegex, Predicate<String> valuePredicate);
 
     /**
      * Get the values of HTTP request headers. The returned Map is case-insensitive wrt. keys and is read-only. The method

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -83,7 +83,7 @@ public interface HttpHeaders {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, String valuleSeparatorRegex, Predicate<String> valuePredicate);
+    public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
 
     /**
      * Get the values of HTTP request headers. The returned Map is case-insensitive wrt. keys and is read-only. The method

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -68,6 +68,12 @@ public interface HttpHeaders {
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -106,7 +106,7 @@ public interface HttpHeaders {
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+    public default boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
         return containsHeaderString(name, ",", valuePredicate);
     }
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -70,8 +70,8 @@ public interface HttpHeaders {
      *
      * @param name the message header.
      * @param valuePredicate value must fulfil this predicate.
-     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
-     * comma-separated header string contains value as a whole word.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
      * @see #getRequestHeaders()
      * @see #getHeaderString(String)
      * @since 4.0

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -69,13 +69,13 @@ public interface HttpHeaders {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * <p>
-     * For example: {@code containsHeaderString("cache-control", null, "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * For example: {@code containsHeaderString("cache-control", ",", "no-store"::equalsIgnoreCase)} will return {@code true} if
      * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
      * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
      * (missing comma), or the value {@code no - store} (whitespace within value).
      *
      * @param name the message header.
-     * @param valueSeparatorRegex Separates the header value into single values. Defaults to {@code \s*,\s*} when {@code null}.
+     * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
      * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -62,7 +62,7 @@ public interface HttpHeaders {
     public String getHeaderString(String name);
 
     /**
-     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.
      *
      * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
@@ -78,12 +78,37 @@ public interface HttpHeaders {
      * @param valueSeparatorRegex Separates the header value into single values. {@code null} does not split.
      * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
-     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * matching the predicate, or having at least one whitespace-trimmed single value in a token-separated list of single values.
      * @see #getRequestHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
     public boolean containsHeaderString(String name, String valueSeparatorRegex, Predicate<String> valuePredicate);
+
+    /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * <p>
+     * For example: {@code containsHeaderString("cache-control", "no-store"::equalsIgnoreCase)} will return {@code true} if
+     * a {@code Cache-Control} header exists that has the value {@code no-store}, the value {@code No-Store} or the value
+     * {@code Max-Age, NO-STORE, no-transform}, but {@code false} when it has the value {@code no-store;no-transform}
+     * (missing comma), or the value {@code no - store} (whitespace within value).
+     *
+     * @param name the message header.
+     * @param valuePredicate value must fulfil this predicate.
+     * @return {@code true} if and only if a header with the given name exists, having either a whitespace-trimmed value
+     * matching the predicate, or having at least one whitespace-trimmed single value in a comma-separated list of single values.
+     * @see #getRequestHeaders()
+     * @see #getHeaderString(String)
+     * @since 4.0
+     */
+    default public boolean containsHeaderString(String name, Predicate<String> valuePredicate) {
+        return containsHeaderString(name, ",", valuePredicate);
+    }
 
     /**
      * Get the values of HTTP request headers. The returned Map is case-insensitive wrt. keys and is read-only. The method

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -48,7 +48,7 @@ public interface HttpHeaders {
      * <p>
      * Get a HTTP header as a single string value.
      * </p>
-     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
@@ -64,7 +64,7 @@ public interface HttpHeaders {
     /**
      * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
      *
-     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -61,6 +61,23 @@ public interface HttpHeaders {
     public String getHeaderString(String name);
 
     /**
+     * Checks whether a header with a specific name and value (or item of the comma-separated value list) exists.
+     *
+     * Each single header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * @param name the message header.
+     * @param value the message header value.
+     * @param ignoreCase whether to ignore upper/lower case.
+     * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
+     * comma-separated header string contains value as a whole word.
+     * @see #getRequestHeaders()
+     * @see #getHeaderString(String)
+     */
+    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+
+    /**
      * Get the values of HTTP request headers. The returned Map is case-insensitive wrt. keys and is read-only. The method
      * never returns {@code null}.
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * An injectable interface that provides access to HTTP header information. All methods throw
@@ -68,15 +69,14 @@ public interface HttpHeaders {
      * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the message header.
-     * @param value the message header value.
-     * @param ignoreCase whether to ignore upper/lower case.
+     * @param valuePredicate value must fulfil this predicate.
      * @return {@code true} if and only if a header with the provided name exists having either the exact value or whose
      * comma-separated header string contains value as a whole word.
      * @see #getRequestHeaders()
      * @see #getHeaderString(String)
      * @since 4.0
      */
-    public boolean containsHeaderString(String name, String value, boolean ignoreCase);
+    public boolean containsHeaderString(String name, Predicate<String> valuePredicate);
 
     /**
      * Get the values of HTTP request headers. The returned Map is case-insensitive wrt. keys and is read-only. The method


### PR DESCRIPTION
For release 4.0 I'd like to propose a convencience method for response/request contexts which I missed a lot in the past years and which I implemented again and again in multiple ways -- most of them lacking either performance or perfection.

The problem it solves is that it is rather hard to get it perfectly correct checking for items in comma-separated headers - without losing valuable performance.

Example: How to check if there is a `Cache-Control: no-store` value set in case the actual sent headers contains `Cache-Control` multiple times and each of the findings is possibly a comma-separated list? RegEx over getHeaderString() comes into mind, but this is rather slow, as it first concatenates everything just to split it up afterwards. Iterating all findings comes into mind next, which is everything but convenient nor particularly readable.

Solution: An implementation of this new method would be provided by the runtime vendor, hence could provide not only most convenient usage to the caller, but also perform best possible as it is optimized according to the actual implementation's internal map design

WDYT?