### PR TITLE
TCK changes : Move new tests to renamed package, fix epl tck bundle generation

### DIFF
--- a/jaxrs-tck-docs/JAXRSTCK3.1-ReleaseNotes.html
+++ b/jaxrs-tck-docs/JAXRSTCK3.1-ReleaseNotes.html
@@ -74,7 +74,7 @@ td {  padding-left: 3pt;}
     <h2>Jakarta EE RESTful Web Services 3.1 TCK Facts</h2>
     <p>The test suite bundle contains the following:</p>
     <ul>
-      <li>2792 total tests</li>
+      <li>2795 total tests</li>
     </ul>
     <hr>
     <h2>Platform Notes</h2>

--- a/jaxrs-tck-docs/tckbundle.sh
+++ b/jaxrs-tck-docs/tckbundle.sh
@@ -27,7 +27,10 @@ if [ -z "$VERSION" ]; then
 fi
 
 if [[ "$1" == "epl" || "$1" == "EPL" ]]; then
-    mvn clean install -Dtck.artifactId=restful-ws-tck
+    mvn clean install
+    sed "s/jakarta-restful-ws-tck/restful-ws-tck/g" $WORKSPACE/jaxrs-tck/pom.xml > $WORKSPACE/jaxrs-tck/pom.epl.xml
+    cd $WORKSPACE/jaxrs-tck
+    mvn clean install -f pom.epl.xml
 else
     mvn clean install
 fi
@@ -55,7 +58,7 @@ cd $WORKSPACE/bundle
 
 if [[ "$1" == "epl" || "$1" == "EPL" ]]; then
     cp $WORKSPACE/LICENSE.md $WORKSPACE/bundle/LICENSE.md
-    cp $WORKSPACE/jaxrs-tck/pom.xml $WORKSPACE/bundle/restful-ws-tck-"$VERSION".pom
+    cp $WORKSPACE/jaxrs-tck/pom.epl.xml $WORKSPACE/bundle/restful-ws-tck-"$VERSION".pom
     zip -r restful-ws-tck-"$VERSION".zip *
 else
     cp $WORKSPACE/jaxrs-tck-docs/LICENSE_EFTL.md $WORKSPACE/bundle/LICENSE.md

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/DynamicFeatureResource.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/DynamicFeatureResource.java
@@ -14,19 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.ws.rs.tck.jaxrs31.spec.extensions;
+package ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions;
 
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
-import java.util.HashSet;
-import java.util.Set;
+@Path("/")
+public class DynamicFeatureResource {
 
-@ApplicationPath("/")
-public class TSAppConfig extends Application {
-  public Set<Class<?>> getClasses() {
-    Set<Class<?>> resources = new HashSet<>();
-    resources.add(DynamicFeatureResource.class);
-    return resources;
-  }
+    @GET
+    @Path("dynamicFeature")
+    public Response getDynamicFeature() {
+        return Response.ok().build();
+    }
 }

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/JAXRSClientIT.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.ws.rs.tck.jaxrs31.spec.extensions;
+package ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions;
 
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.container.DynamicFeature;

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/TSAppConfig.java
@@ -14,18 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.ws.rs.tck.jaxrs31.spec.extensions;
+package ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
-@Path("/")
-public class DynamicFeatureResource {
+import java.util.HashSet;
+import java.util.Set;
 
-    @GET
-    @Path("dynamicFeature")
-    public Response getDynamicFeature() {
-        return Response.ok().build();
-    }
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+  public Set<Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<>();
+    resources.add(DynamicFeatureResource.class);
+    return resources;
+  }
 }

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/TckDynamicFeature.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/TckDynamicFeature.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.ws.rs.tck.jaxrs31.spec.extensions;
+package ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/TckFeature.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/TckFeature.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.ws.rs.tck.jaxrs31.spec.extensions;
+package ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;


### PR DESCRIPTION
Requesting fast track as it involves : 

- TCK changes to correct the package names of newly added tests in jaxrs31/ folder.
- correct the EPL TCK bundle generation script.
- update the total test count in Release Notes as 2795 (this includes the test in this PR and PR 976)

@jansupol @spericas 