### PR TITLE
Maven profile jaxrs.jerseytck.build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,5 +72,16 @@
                 <module>jaxrs-spec</module>
             </modules>
         </profile>
+        <profile>
+            <id>jersey-tck</id>
+            <activation>
+                <property>
+                    <name>jaxrs.jerseytck.build</name>
+                </property>
+            </activation>
+            <modules>
+                <module>jersey-tck</module>
+            </modules>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This PR proposes the introduction of a new Maven profile `jaxrs.jerseytck.build` to make the testing of new TCK tests easier.

*Without* this PR, the current way of developing new TCK tests is to *install* the modified TCK into the local Maven repository, then run jersey-tck as a proof-of-concept (like a beta-test for the new TCK test). The installation in local Maven repository is mandatory, as jersey-tck is not a module of the JAX-RS top-level POM, hence would not see the current TCK changes otherwise.

Installing work-in-progress in the local Maven repository is very bad, as several parallel projects could never rely on "their" current state of the TCK: You cannot test multiple TCK changes in parallel branches, as only one version of the TCK can be installed at any time.

The way to go (or: THE Maven way) are *reactor builds*, so each running Maven instance builds "its" TCK version separately, *not* installing it, but using it solely for the purpose of the current jersey-tck run. To enable this feature, jersey-tck must become a top-level POM member module.

*With* this PR, reactor builds are possible, so no more "mvn install" of the TCK is needed anymore to run jersey-tck, hence multiple branches can be tested without race conditions wrt. the local Maven repository:

`mvn -am -pl -Djaxrs.jerseytck.build :jersey-tck verify`

This PR does not induce any harm to existing functionality, as the new profile *only* is active once *explicitly, manually* enabled at the command line.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**