### PR TITLE
add dependencies to run tck independently

### DIFF
--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -38,9 +38,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jersey.version>3.1.0-M3</jersey.version>
-        <glassfish.container.version>6.2.3</glassfish.container.version>
+        <glassfish.container.version>6.2.5</glassfish.container.version>
         <glassfish.home>${project.build.directory}/glassfish6</glassfish.home>
-        <jakarta.platform.version>9.1.0</jakarta.platform.version>
+        <jakarta.platform.version>10.0.0-RC1</jakarta.platform.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <jakarta.rest.version>3.1.0</jakarta.rest.version>
         <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
@@ -95,6 +95,20 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>${tck.artifactId}</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -161,12 +175,6 @@
 
     </dependencies>
 
-
-    <profiles>
-        <profile>
-            <id>arq-glassfish-managed</id>
-        </profile>
-    </profiles>
 
     <build>	    
     <plugins>


### PR DESCRIPTION
Adding dependency jars in jersey-tck/pom.xml to run the module independently. 
Requesting fast-track. 
@spericas @jansupol 