### PR TITLE
Removed unnecessary workarond for ephemerial port

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/common/util/JaxrsUtil.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/common/util/JaxrsUtil.java
@@ -35,15 +35,10 @@ import java.util.TimeZone;
 
 public abstract class JaxrsUtil {
 
-  public static final int unprivilegedPort() throws IOException {
-    for (int i = 0; i < 1025; i++) {
-      try (final ServerSocket serverSocket = new ServerSocket(0)) {
-        final int port = serverSocket.getLocalPort();
-        if (port > 1024)
-          return port;
-      }
+  public static final int freePort() throws IOException {
+    try (final ServerSocket serverSocket = new ServerSocket(0)) {
+      return serverSocket.getLocalPort();
     }
-    throw new IOException("No free unprivileged port");
   }
 
   public static final//

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/sebootstrap/SeBootstrapIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/sebootstrap/SeBootstrapIT.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
-import static ee.jakarta.tck.ws.rs.common.util.JaxrsUtil.unprivilegedPort;
+import static ee.jakarta.tck.ws.rs.common.util.JaxrsUtil.freePort;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -371,7 +371,7 @@ public final class SeBootstrapIT {
     };
 
     private static final int someFreeIpPort() throws IOException {
-        return unprivilegedPort();
+        return freePort();
     }
 
     private static final int mockInt() {

--- a/jaxrs-tck/src/test/java/ee/jakarta/tck/ws/rs/common/util/JaxrsUtilTest.java
+++ b/jaxrs-tck/src/test/java/ee/jakarta/tck/ws/rs/common/util/JaxrsUtilTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
-import static ee.jakarta.tck.ws.rs.common.util.JaxrsUtil.unprivilegedPort;
+import static ee.jakarta.tck.ws.rs.common.util.JaxrsUtil.freePort;
 
 import java.io.IOException;
 
@@ -29,12 +29,12 @@ import org.junit.jupiter.api.Test;
 final class JaxrsUtilTest {
 
     @Test
-    final void shouldReturnPortLarger1024() throws IOException {
+    final void shouldReturnPortFreePort() throws IOException {
         // when
-        final int chosenPort = unprivilegedPort();
+        final int chosenPort = freePort();
 
         // then
-        assertThat(chosenPort, is(greaterThan(1024)));
+        assertThat(chosenPort, is(greaterThan(0)));
     }
 
 }


### PR DESCRIPTION
This PR removes an unnecessary workaround: There is not need to check the port number, as nobody ever has seen any JRE on any OS that returned a non-ephemerial port. Oracle's OpenJDK team even disputes that this could happen ever, and there is no proof that there would be a bug. Hence we should not fix something that is not broken.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**