### PR TITLE
Jakarta Staging Repository

### DIFF
--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -46,6 +46,14 @@
         <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
     </properties>
 
+    <repositories>
+        <repository>
+            <name>Jakarta Staging</name>
+            <id>jakarta-staging</id>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/staging</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
This PR adds the Jakarta Staging Repository (*additionally* to the local machine's repository settings) to the jersey-tck pom. This addition allows to use binary Jersey instead of mvn install Jersey from scratch without knowledge where to find pre-release builds. As such, it makes test-driving the TCK much more agile, as no local Jersey source code is needed at all.