### PR TITLE
Added 422 status code

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
@@ -1344,6 +1344,13 @@ public abstract class Response implements AutoCloseable {
          */
         EXPECTATION_FAILED(417, "Expectation Failed"),
         /**
+         * 422 Unprocessable entity, see <a href="https://datatracker.ietf.org/doc/html/rfc4918#section-11.2">RFC 4918
+         * Status Codes</a>.
+         *
+         * @since 2.2
+         */
+        UNPROCESSABLE_ENTITY(422, "Unprocessable Entity"),
+        /**
          * 428 Precondition required, see <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional HTTP
          * Status Codes</a>.
          *

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/core/responseclient/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/core/responseclient/JAXRSClientIT.java
@@ -96,7 +96,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   // name it to ensure sorting
   protected final int[] status_codes = { 200, 201, 202, 204, 205, 206, 300, 301, 302,
       303, 304, 305, 307, 308, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410,
-      411, 412, 413, 414, 415, 416, 417, 428, 429, 431, 451, 500, 501, 502, 503, 504,
+      411, 412, 413, 414, 415, 416, 417, 422, 428, 429, 431, 451, 500, 501, 502, 503, 504,
       505, 511 };
 
   // name it to ensure sorting
@@ -119,10 +119,10 @@ public class JAXRSClientIT extends JAXRSCommonClient {
       Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
       Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
       Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
-      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.SERVER_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
       Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
       Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
-      Response.Status.Family.SERVER_ERROR,
+      Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
       Response.Status.Family.SERVER_ERROR };
 
   protected final Response.Status.Family[] status_family_list = {
@@ -138,7 +138,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
       "Proxy Authentication Required", "Request Timeout", "Conflict", "Gone",
       "Length Required", "Precondition Failed", "Request Entity Too Large",
       "Request-URI Too Long", "Unsupported Media Type",
-      "Requested Range Not Satisfiable", "Expectation Failed",
+      "Requested Range Not Satisfiable", "Expectation Failed", "Unprocessable Entity",
       "Precondition Required", "Too Many Requests",
       "Request Header Fields Too Large", "Unavailable For Legal Reasons", "Internal Server Error",
       "Not Implemented", "Bad Gateway", "Service Unavailable",

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/core/responsestatustype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/core/responsestatustype/JAXRSClientIT.java
@@ -53,7 +53,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   // name it to ensure sorting
   static final int[] status_codes = { 200, 201, 202, 204, 205, 206, 301, 302,
       303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410,
-      411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505 };
+      411, 412, 413, 414, 415, 416, 417, 422, 500, 501, 502, 503, 504, 505 };
 
   // name it to ensure sorting
   static final Response.Status.Family[] status_family = {
@@ -72,9 +72,9 @@ public class JAXRSClientIT extends JAXRSCommonClient {
       Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
       Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
       Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.SERVER_ERROR,
       Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
       Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
-      Response.Status.Family.SERVER_ERROR,
       Response.Status.Family.SERVER_ERROR };
 
   final String[] status = { "OK", "Created", "Accepted", "No Content",
@@ -85,7 +85,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
       "Proxy Authentication Required", "Request Timeout", "Conflict", "Gone",
       "Length Required", "Precondition Failed", "Request Entity Too Large",
       "Request-URI Too Long", "Unsupported Media Type",
-      "Requested Range Not Satisfiable", "Expectation Failed",
+      "Requested Range Not Satisfiable", "Expectation Failed", "Unprocessable Entity",
       "Internal Server Error", "Not Implemented", "Bad Gateway",
       "Service Unavailable", "Gateway Timeout", "HTTP Version Not Supported" };
 


### PR DESCRIPTION
In [RFC 4918](https://datatracker.ietf.org/doc/html/rfc4918) there is a list of Status Code Extensions to HTTP/1.1 [RFC2616] being 422 the most widely adopted and used.