### PR TITLE
exclude additional Jakarta XML Binding tests that were previously excluded in the Jakarta EE Platform TCK

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/core/linkjaxbadapter/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/core/linkjaxbadapter/JAXRSClientIT.java
@@ -37,6 +37,8 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 
+import org.junit.jupiter.api.Tag;
+
 /*
  * @class.setup_props: webServerHost;
  *                     webServerPort;
@@ -76,6 +78,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
      * @test_Strategy:
      */
     @Test
+    @Tag("xml_binding")
     public void marshallTest() throws Fault {
         Link link = RuntimeDelegate.getInstance().createLinkBuilder().uri(url).title(title).rel(rel).type(media)
                 .param(param_names[0], param_vals[0]).param(param_names[1], param_vals[1]).build();
@@ -122,6 +125,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
      * @test_Strategy: Test whether a class with Link can be unmarshalled fine
      */
     @Test
+    @Tag("xml_binding")
     public void unmarshallTest() throws Fault {
 
         Link link = RuntimeDelegate.getInstance().createLinkBuilder().uri(url).title(title).rel(rel).type(media)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java
@@ -47,6 +47,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -284,6 +285,7 @@ public class JAXRSClientIT extends SSEJAXRSClient {
    * @test_Strategy:
    */
   @Test
+  @Tag("xml_binding")
   public void jaxbElementTest() throws Fault {
     Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/jaxbelement");
     logTrace("Received", holder.get());

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
@@ -63,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -496,6 +497,7 @@ public class JAXRSClientIT extends SSEJAXRSClient {
    * @test_Strategy:
    */
   @Test
+  @Tag("xml_binding")
   public void jaxbElementTest() throws Fault {
     mediaTestLevel = 3;
     @SuppressWarnings("unchecked")
@@ -519,6 +521,7 @@ public class JAXRSClientIT extends SSEJAXRSClient {
    * @test_Strategy:
    */
   @Test
+  @Tag("xml_binding")
   public void xmlTest() throws Fault {
     mediaTestLevel = 2;
     BiPredicate<Object, Object> p = (a, b) -> ((JaxbKeyValueBean) b).getValue().equals(a);

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardhaspriority/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardhaspriority/JAXRSClientIT.java
@@ -124,6 +124,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * same mediaType
    */
   @Test
+  @Tag("xml_binding")
   public void readWriteMapProviderTest() throws Fault {
     MultivaluedMap<String, String> map = new MultivaluedHashMap<String, String>();
     map.add("map", "map");
@@ -144,6 +145,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * same mediaType
    */
   @Test
+  @Tag("xml_binding")
   public void readWriteBooleanProviderTest() throws Fault {
     MediaType mt = MediaType.TEXT_PLAIN_TYPE;
     setProperty(Property.REQUEST, buildRequest(Request.POST, "boolean"));
@@ -167,6 +169,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * same mediaType
    */
   @Test
+  @Tag("xml_binding")
   public void readWriteCharacterProviderTest() throws Fault {
     MediaType mt = MediaType.TEXT_PLAIN_TYPE;
     setProperty(Property.REQUEST, buildRequest(Request.POST, "character"));
@@ -190,6 +193,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * same mediaType
    */
   @Test
+  @Tag("xml_binding")
   public void readWriteIntegerProviderTest() throws Fault {
     MediaType mt = MediaType.TEXT_PLAIN_TYPE;
     setProperty(Property.REQUEST, buildRequest(Request.POST, "number"));


### PR DESCRIPTION
While running the TCK without Jakarta XML Binding present, we've been running into failures with these tests that were previously excluded in the Jakarta EE Platform TCK.