### PR TITLE
version changes for tck service release 3.1.1

### DIFF
--- a/jaxrs-tck-docs/tckbundle.sh
+++ b/jaxrs-tck-docs/tckbundle.sh
@@ -23,7 +23,7 @@ cd $WORKSPACE
 export VERSION="$2"
 
 if [ -z "$VERSION" ]; then
-  export VERSION="3.1.0"
+  export VERSION="3.1.1"
 fi
 
 if [[ "$1" == "epl" || "$1" == "EPL" ]]; then

--- a/jaxrs-tck-docs/userguide/pom.xml
+++ b/jaxrs-tck-docs/userguide/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>tck_jaxrs</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta RESTful Web Services for Jakarta EE, Release 3.1</name>
 
     <properties>

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/attributes.conf
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/attributes.conf
@@ -26,7 +26,7 @@
 :MavenVersion: 3.6.3+
 :JakartaEEVersion: 10
 :excludeListFileName: jaxrs-tck-docs/TCK-Exclude-List.txt
-:TCKPackageName: jakarta-restful-ws-tck-3.1.0.zip
+:TCKPackageName: jakarta-restful-ws-tck-x.y.z.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: ee.jakarta.tck.ws.rs.signaturetest.jaxrs
 :singleTestDirectoryExample: ee.jakarta.tck.ws.rs.api.rs.get

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -26,6 +26,7 @@
     <name>Jakarta RESTful WS TCK</name>
     <description>Technology Compatibility Kit for Jakarta RESTful Web Services</description>
     <url>https://github.com/jakartaee/rest</url>
+    <version>3.1.1</version>
 
     <parent>
         <groupId>jakarta.ws.rs</groupId>
@@ -105,7 +106,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <FileName>${project.build.directory}/jakarta.ws.rs.sig_${project.version}</FileName>
+                            <FileName>${project.build.directory}/jakarta.ws.rs.sig_${project.parent.version}</FileName>
                             <packages>
                                 jakarta.ws.rs,jakarta.ws.rs.client,jakarta.ws.rs.core,jakarta.ws.rs.container,jakarta.ws.rs.ext,jakarta.ws.rs.sse
                             </packages>
@@ -158,7 +159,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.jersey.core</groupId>
     <artifactId>jersey-tck</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This is to append the tck versions from 3.1.0 to 3.1.1 for a new service release. 
The service release of the new TCK needs changes in https://github.com/jakartaee/rest/pull/1117  that is required for core profile going to ballot.

**Requesting fast-track review on this as the changes involved only in tck and new service release is expected that will be used for core profile ballot review.**

cc @jansupol @spericas 