### PR TITLE
Create new test groups - security and servlet

### DIFF
--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/attributes.conf
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/attributes.conf
@@ -26,7 +26,7 @@
 :MavenVersion: 3.6.3+
 :JakartaEEVersion: 10
 :excludeListFileName: jaxrs-tck-docs/TCK-Exclude-List.txt
-:excludedGroupsExample: xml_binding
+:groupsExample: xml_binding
 :TCKPackageName: jakarta-restful-ws-tck-x.y.z.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: ee.jakarta.tck.ws.rs.signaturetest.jaxrs

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/attributes.conf
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/attributes.conf
@@ -26,6 +26,7 @@
 :MavenVersion: 3.6.3+
 :JakartaEEVersion: 10
 :excludeListFileName: jaxrs-tck-docs/TCK-Exclude-List.txt
+:excludedGroupsExample: xml_binding
 :TCKPackageName: jakarta-restful-ws-tck-x.y.z.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: ee.jakarta.tck.ws.rs.signaturetest.jaxrs

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using-examples.inc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using-examples.inc
@@ -17,25 +17,25 @@ Run the tests by excluding the optional jaxb tests using the following command:
 --
 [source,oac_no_warn]
 ----
-mvn verify -DexcludedGroups="xml_binding"
+mvn verify -DexcludedGroups=xml_binding
 ----
 --
-
-Run the tests by excluding the security tests using the following command:
-
---
-[source,oac_no_warn]
-----
-mvn verify -DexcludedGroups="security"
-----
---
-
-Run the tests by excluding the servlet tests using the following command:
+Run only the optional jaxb tests using the following command:
 
 --
 [source,oac_no_warn]
 ----
-mvn verify -DexcludedGroups="servlet"
+mvn verify -Dgroups=xml_binding
+----
+--
+
+Run the tests by excluding the security & servlet tests using the following 
+command:
+
+--
+[source,oac_no_warn]
+----
+mvn verify -DexcludedGroups=security,servlet
 ----
 --
 

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using-examples.inc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using-examples.inc
@@ -21,6 +21,23 @@ mvn verify -DexcludedGroups="xml_binding"
 ----
 --
 
+Run the tests by excluding the security tests using the following command:
+
+--
+[source,oac_no_warn]
+----
+mvn verify -DexcludedGroups="security"
+----
+--
+
+Run the tests by excluding the servlet tests using the following command:
+
+--
+[source,oac_no_warn]
+----
+mvn verify -DexcludedGroups="servlet"
+----
+--
 
 [[GCMCU]]
 

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
@@ -111,6 +111,30 @@ mvn verify -Dit.test={subsetTestDirectoryExample}.**
 
 The tests in the directory and its subdirectories are run.
 
+[[GBFEP]][[to-exclude-a-subset-of-tests-in-command-line-mode]]
+
+5.2.2 To Exclude a Subset of Tests in Command-Line Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Start the test run by executing the following command: +
+
+[source,subs="attributes"]
+----
+mvn verify -DexcludedGroups={excludedGroupsExample}
+----
+
+The tests in the exclude group `{excludedGroupsExample}` is exclued from the run. 
+
+[NOTE]
+=======================================================================
+
+The Junit test groupings(tags) available in the TCK are `xml_binding`, 
+`security` and `servlet`. These can be used to select or deselect the 
+tests for the execution.
+
+=======================================================================
+
+
 [[GCLRR]][[running-the-tck-against-the-ri]]
 
 5.3 Running the TCK Against another CI

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
@@ -96,7 +96,6 @@ Use the following modes to run a subset of the tests:
 * link:#GBFWK[Section 5.2.1, "To Run a Subset of Tests in Command-Line Mode"]
 
 
-
 [[GBFWK]][[to-run-a-subset-of-tests-in-command-line-mode]]
 
 5.2.1 To Run a Subset of Tests in Command-Line Mode
@@ -111,29 +110,45 @@ mvn verify -Dit.test={subsetTestDirectoryExample}.**
 
 The tests in the directory and its subdirectories are run.
 
-[[GBFEP]][[to-exclude-a-subset-of-tests-in-command-line-mode]]
-
-5.2.2 To Exclude a Subset of Tests in Command-Line Mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Start the test run by executing the following command: +
-
-[source,subs="attributes"]
-----
-mvn verify -DexcludedGroups={excludedGroupsExample}
-----
-
-The tests in the exclude group `{excludedGroupsExample}` is exclued from the run. 
-
 [NOTE]
 =======================================================================
 
-The Junit test groupings(tags) available in the TCK are `xml_binding`, 
+The Junit test tags(groups) available in the TCK are `xml_binding`, 
 `security` and `servlet`. These can be used to select or deselect the 
 tests for the execution.
 
 =======================================================================
 
+[[GBFQA]][[to-run-a-group-of-tests-in-command-line-mode]]
+
+5.2.2 To Run a Group of Tests in Command-Line Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Start the test run by executing the following command: +
+
+[source,subs="attributes"]
+----
+mvn verify -Dgroups={groupsExample}
+----
+
+The tests in the group `{groupsExample}` is exclued from the run. 
+Multiple groups can be separated by comma.
+
+
+[[GBFEP]][[to-exclude-a-group-of-tests-in-command-line-mode]]
+
+5.2.3 To Exclude a Group of Tests in Command-Line Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Start the test run by executing the following command: +
+
+[source,subs="attributes"]
+----
+mvn verify -DexcludedGroups={groupsExample}
+----
+
+The tests in the group `{groupsExample}` is exclued from the run. 
+Multiple groups can be separated by comma.
 
 [[GCLRR]][[running-the-tck-against-the-ri]]
 

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
@@ -131,7 +131,7 @@ Start the test run by executing the following command: +
 mvn verify -Dgroups={groupsExample}
 ----
 
-The tests in the group `{groupsExample}` is exclued from the run. 
+Only the tests in the group +{groupsExample}+ is run. 
 Multiple groups can be separated by comma.
 
 
@@ -147,7 +147,7 @@ Start the test run by executing the following command: +
 mvn verify -DexcludedGroups={groupsExample}
 ----
 
-The tests in the group `{groupsExample}` is exclued from the run. 
+The tests in the group +{groupsExample}+ is exclued from the run. 
 Multiple groups can be separated by comma.
 
 [[GCLRR]][[running-the-tck-against-the-ri]]

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
@@ -117,7 +117,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   @Test
   @Tag("servlet")
   public void getAcceptableLanguagesTest() throws Fault {
-    setProperty(Property.REQUEST_HEADERS, "Accpet-Language:en-us");
+    setProperty(Property.REQUEST_HEADERS, "Accept-Language:en-us");
     invokeRequestAndCheckResponse(ContextOperation.GETACCEPTABLELANGUAGES);
   }
 

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.AfterEach;
 
 /*
@@ -97,6 +98,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void abortWithTest() throws Fault {
     invokeRequestAndCheckResponse(ContextOperation.ABORTWITH);
   }
@@ -113,6 +115,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getAcceptableLanguagesTest() throws Fault {
     setProperty(Property.REQUEST_HEADERS, "Accpet-Language:en-us");
     invokeRequestAndCheckResponse(ContextOperation.GETACCEPTABLELANGUAGES);
@@ -130,6 +133,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getAcceptableLanguagesIsSortedTest() throws Fault {
     logMsg(
         "Check the #getAcceptableLanguages is sorted according to their q-value");
@@ -153,6 +157,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getAcceptableLanguagesIsReadOnlyTest() throws Fault {
     setProperty(Property.REQUEST_HEADERS,
         "Accept-Language: da, en-gb;q=0.6, en-us;q=0.7");
@@ -173,6 +178,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getAcceptableMediaTypesTest() throws Fault {
     setProperty(Property.REQUEST_HEADERS,
         buildAccept(MediaType.APPLICATION_JSON_TYPE));
@@ -192,6 +198,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getAcceptableMediaTypesIsSortedTest() throws Fault {
     logMsg(
         "Check the #getAcceptableMediaTypes is sorted according to their q-value");
@@ -217,6 +224,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getAcceptableMediaTypesIsReadOnlyTest() throws Fault {
     setProperty(Property.REQUEST_HEADERS, buildAccept(MediaType.TEXT_XML_TYPE));
     setProperty(Property.UNEXPECTED_RESPONSE_MATCH, MediaType.APPLICATION_JSON);
@@ -235,6 +243,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getCookiesTest() throws Fault {
     String[] cookies = { "cookie1", "coookkkie99", "cookiiieee999" };
     for (String cookie : cookies) {
@@ -258,6 +267,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getCookiesIsReadonlyTest() throws Fault {
     setPrintEntity(true);
     invokeRequestAndCheckResponse(ContextOperation.GETCOOKIESISREADONLY);
@@ -274,6 +284,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getDateTest() throws Fault {
     Calendar calendar = Calendar.getInstance();
     calendar.set(Calendar.MILLISECOND, 0);
@@ -296,6 +307,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getDateIsNullTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "NULL");
     invokeRequestAndCheckResponse(ContextOperation.GETDATE);
@@ -312,6 +324,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getEntityStreamTest() throws Fault {
     String entity = "EnTiTyStReAmTeSt";
     setProperty(Property.CONTENT, entity);
@@ -331,6 +344,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getHeadersTest() throws Fault {
     for (int i = 1; i != 5; i++) {
       String header = "header" + i + ":" + "header" + i;
@@ -351,6 +365,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getHeadersIsMutableTest() throws Fault {
     setPrintEntity(true);
     invokeRequestAndCheckResponse(ContextOperation.GETHEADERSISMUTABLE);
@@ -367,6 +382,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getHeaderStringTest() throws Fault {
     setProperty(Property.SEARCH_STRING,
         ContextOperation.GETHEADERSTRING2.name());
@@ -384,6 +400,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getLanguageTest() throws Fault {
     setProperty(Property.REQUEST_HEADERS,
         HttpHeaders.CONTENT_LANGUAGE + ":en-gb");
@@ -402,6 +419,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getLanguageIsNullTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "NULL");
     invokeRequestAndCheckResponse(ContextOperation.GETLANGUAGE);
@@ -419,6 +437,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getLengthTest() throws Fault {
     setProperty(Property.CONTENT, "12345678901234567890");
     setProperty(Property.SEARCH_STRING, "20");
@@ -437,6 +456,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getLengthWhenNoEntityTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "-1");
     invokeRequestAndCheckResponse(ContextOperation.GETLENGTH);
@@ -454,6 +474,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getMediaTypeTest() throws Fault {
     addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_SVG_XML);
     setProperty(Property.SEARCH_STRING, MediaType.APPLICATION_SVG_XML);
@@ -472,6 +493,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getMediaTypeIsNullTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "NULL");
     invokeRequestAndCheckResponse(ContextOperation.GETMEDIATYPE);
@@ -488,6 +510,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getMethodTest() throws Fault {
     String method = Request.OPTIONS.name();
     String header = RequestFilter.OPERATION + ":"
@@ -512,6 +535,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getPropertyIsNullTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "NULL");
     invokeRequestAndCheckResponse(ContextOperation.GETPROPERTY);
@@ -530,6 +554,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getPropertyNamesTest() throws Fault {
     for (int i = 0; i != 5; i++)
       setProperty(Property.UNORDERED_SEARCH_STRING,
@@ -547,6 +572,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * request/response exchange context.
    */
   @Test
+  @Tag("servlet")
   public void getPropertyNamesIsReadOnlyTest() throws Fault {
     setProperty(Property.UNORDERED_SEARCH_STRING, "0");
     invokeRequestAndCheckResponse(ContextOperation.GETPROPERTYNAMESISREADONLY);
@@ -563,6 +589,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getRequestTest() throws Fault {
     String method = Request.OPTIONS.name();
     String header = RequestFilter.OPERATION + ":"
@@ -587,6 +614,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getSecurityContextPrincipalIsNullTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "NULL");
     invokeRequestAndCheckResponse(ContextOperation.GETSECURITYCONTEXT);
@@ -603,6 +631,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void getUriInfoTest() throws Fault {
     setProperty(Property.SEARCH_STRING, getAbsoluteUrl());
     invokeRequestAndCheckResponse(ContextOperation.GETURIINFO);
@@ -620,6 +649,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void hasEntityTest() throws Fault {
     setRequestContentEntity("entity");
     setProperty(Property.SEARCH_STRING, "true");
@@ -638,6 +668,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void hasEntityWhenNoEntityTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "false");
     invokeRequestAndCheckResponse(ContextOperation.HASENTITY);
@@ -657,6 +688,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void removePropertyTest() throws Fault {
     // getProperty returns null after the property has been set and removed
     setProperty(Property.SEARCH_STRING, "NULL");
@@ -674,6 +706,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void setEntityStreamTest() throws Fault {
     setProperty(Property.SEARCH_STRING, RequestFilter.SETENTITYSTREAMENTITY);
     invokeRequestAndCheckResponse(ContextOperation.SETENTITYSTREAM);
@@ -690,6 +723,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void setMethodTest() throws Fault {
     setProperty(Property.SEARCH_STRING, Request.OPTIONS.name());
     invokeRequestAndCheckResponse(ContextOperation.SETMETHOD);
@@ -709,6 +743,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void setPropertyTest() throws Fault {
     setProperty(Property.SEARCH_STRING, TemplateFilter.PROPERTYNAME);
     invokeRequestAndCheckResponse(ContextOperation.SETPROPERTY);
@@ -727,6 +762,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException. *
    */
   @Test
+  @Tag("servlet")
   public void setPropertyNullTest() throws Fault {
     setProperty(Property.SEARCH_STRING, "NULL");
     invokeRequestAndCheckResponse(ContextOperation.SETPROPERTYNULL);
@@ -746,6 +782,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException. *
    */
   @Test
+  @Tag("servlet")
   public void setPropertyIsReflectedInServletRequestTest() throws Fault {
     setProperty(Property.SEARCH_STRING, RequestFilter.PROPERTYNAME);
     invokeRequestAndCheckResponse(ContextOperation.SETPROPERTYCONTEXT);
@@ -763,6 +800,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void setRequestUriOneUriTest() throws Fault {
     setProperty(Property.SEARCH_STRING, RequestFilter.URI);
     invokeRequestAndCheckResponse(ContextOperation.SETREQUESTURI1);
@@ -780,6 +818,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void setRequestUriTwoUrisTest() throws Fault {
     setProperty(Property.SEARCH_STRING, RequestFilter.URI);
     invokeRequestAndCheckResponse(ContextOperation.SETREQUESTURI2);
@@ -797,6 +836,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Tag("servlet")
   public void setSecurityContextTest() throws Fault {
     setProperty(Property.SEARCH_STRING, RequestFilter.PRINCIPAL);
     invokeRequestAndCheckResponse(ContextOperation.SETSECURITYCONTEXT);

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/securitycontext/basic/JAXRSBasicClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/securitycontext/basic/JAXRSBasicClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.AfterEach;
 
 /*
@@ -104,6 +105,7 @@ public class JAXRSBasicClientIT
    * @test_Strategy: Send no authorization, make sure of 401 response
    */
   @Test
+  @Tag("security")
   @RunAsClient
   public void noAuthorizationTest() throws Fault {
     super.noAuthorizationTest();
@@ -118,6 +120,7 @@ public class JAXRSBasicClientIT
    * @test_Strategy: Send basic authorization, check security context
    */
   @Test
+  @Tag("security")
   @RunAsClient
   public void basicAuthorizationAdminTest() throws Fault {
     setProperty(Property.STATUS_CODE, getStatusCode(Response.Status.OK));
@@ -139,6 +142,7 @@ public class JAXRSBasicClientIT
    * @test_Strategy: Send basic authorization, check security context
    */
   @Test
+  @Tag("security")
   @RunAsClient
   public void basicAuthorizationIncorrectUserTest() throws Fault {
     setProperty(Property.STATUS_CODE,
@@ -156,6 +160,7 @@ public class JAXRSBasicClientIT
    * @test_Strategy: Send basic authorization, check security context
    */
   @Test
+  @Tag("security")
   @RunAsClient
   public void basicAuthorizationIncorrectPasswordTest() throws Fault {
     setProperty(Property.STATUS_CODE,
@@ -175,6 +180,7 @@ public class JAXRSBasicClientIT
    * context
    */
   @Test
+  @Tag("security")
   @RunAsClient
   public void basicAuthorizationStandardUserTest() throws Fault {
     setProperty(Property.STATUS_CODE, getStatusCode(Response.Status.OK));


### PR DESCRIPTION
Resolves https://github.com/jakartaee/rest/issues/1120 & https://github.com/jakartaee/rest/issues/1121 .
Related Issue : https://github.com/eclipse-ee4j/jakartaee-tck/issues/1097 

Two new test groups (Junit Tags) are created - "security" & "servlet", so that they can be excluded when run against Core profile.

**Requesting fast-track review on this as the changes are involved only in tck. The new service release (3.1.1) of the TCK that will be used for core profile ballot review requires these changes.**

cc  @jansupol @spericas @starksm64 @brideck
