### PR TITLE
Update testgroup "security" with more tests

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/security/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/security/JAXRSClientIT.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 
 /*
  * @class.setup_props: webServerHost;
@@ -109,6 +110,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    */
   @RunAsClient
   @Test
+  @Tag("security")
   public void getSecurityContextTest() throws Fault {
     setProperty(Property.BASIC_AUTH_USER, user);
     setProperty(Property.BASIC_AUTH_PASSWD, password);
@@ -127,6 +129,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    */
   @RunAsClient
   @Test
+  @Tag("security")
   public void noSecurityTest() throws Fault {
     String request = buildRequest(Request.POST, "");
     setProperty(Property.REQUEST, request);


### PR DESCRIPTION
Resolves https://github.com/jakartaee/rest/issues/1121 

Related Issue : https://github.com/eclipse-ee4j/jakartaee-tck/issues/1097

More tests are added to test group (Junit Tags) "security"  that was missed in https://github.com/jakartaee/rest/pull/1122. 

**Requesting fast-track review on this as the changes are involved only in tck. The new service release (3.1.1) of the TCK will be updated with this change and will be used for core profile ballot review.**

cc @brideck @jansupol @arjantijms @spericas @starksm64 