### PR TITLE
New tag for SEbootstrap tests - issue 1128

### DIFF
--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using-examples.inc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using-examples.inc
@@ -28,6 +28,15 @@ Run only the optional jaxb tests using the following command:
 mvn verify -Dgroups=xml_binding
 ----
 --
+Run the tests by excluding the optional SEBootstrap tests using the 
+following command:
+
+--
+[source,oac_no_warn]
+----
+mvn verify -DexcludedGroups=se_bootstrap
+----
+--
 
 Run the tests by excluding the security & servlet tests using the following 
 command:

--- a/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/content/using.adoc
@@ -114,8 +114,8 @@ The tests in the directory and its subdirectories are run.
 =======================================================================
 
 The Junit test tags(groups) available in the TCK are `xml_binding`, 
-`security` and `servlet`. These can be used to select or deselect the 
-tests for the execution.
+`security`, `servlet` and `se_bootstrap`. These can be used to select or 
+deselect the tests for the execution. 
 
 =======================================================================
 

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/sebootstrap/SeBootstrapIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/sebootstrap/SeBootstrapIT.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Tag;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
@@ -62,6 +63,7 @@ public final class SeBootstrapIT {
      *                              expected
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceUsingDefaults() throws InterruptedException, ExecutionException {
         // given
         final int expectedResponse = mockInt();
@@ -97,6 +99,7 @@ public final class SeBootstrapIT {
      * @throws IOException          if no IP port was free
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceUsingProperties() throws InterruptedException, ExecutionException, IOException {
         // given
         final int expectedResponse = mockInt();
@@ -136,6 +139,7 @@ public final class SeBootstrapIT {
      * @throws IOException          if no IP port was free
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceUsingConvenienceMethods()
             throws InterruptedException, ExecutionException, IOException {
         // given
@@ -172,6 +176,7 @@ public final class SeBootstrapIT {
      * @throws IOException          if no IP port was free
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceUsingExternalConfiguration()
             throws InterruptedException, ExecutionException, IOException {
         // given
@@ -222,6 +227,7 @@ public final class SeBootstrapIT {
      * @throws IOException          if no IP port was free
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceDespiteUnknownConfigurationParameters()
             throws InterruptedException, ExecutionException, IOException {
         // given
@@ -265,6 +271,7 @@ public final class SeBootstrapIT {
      *                              expected
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceUsingSelfDetectedFreeIpPort()
             throws InterruptedException, ExecutionException {
         // given
@@ -301,6 +308,7 @@ public final class SeBootstrapIT {
      *                              expected
      */
     @Test
+    @Tag("se_bootstrap")
     public final void shouldBootInstanceUsingImplementationsDefaultIpPort()
             throws InterruptedException, ExecutionException {
         // given


### PR DESCRIPTION
Fixes https://github.com/jakartaee/rest/issues/1128 

Create new tag 'se_bootstrap' for SE bootstrap tests in ee.jakarta.tck.ws.rs.sebootstrap.SeBootstrapIT.java


cc @spericas @jansupol @jim-krueger @mkarg 