### PR TITLE
Version changes for tck service release 3.1.2

### DIFF
--- a/jaxrs-tck-docs/tckbundle.sh
+++ b/jaxrs-tck-docs/tckbundle.sh
@@ -23,7 +23,7 @@ cd $WORKSPACE
 export VERSION="$2"
 
 if [ -z "$VERSION" ]; then
-  export VERSION="3.1.1"
+  export VERSION="3.1.2"
 fi
 
 if [[ "$1" == "epl" || "$1" == "EPL" ]]; then

--- a/jaxrs-tck-docs/userguide/pom.xml
+++ b/jaxrs-tck-docs/userguide/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>tck_jaxrs</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta RESTful Web Services for Jakarta EE, Release 3.1</name>
 
     <properties>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -26,7 +26,7 @@
     <name>Jakarta RESTful WS TCK</name>
     <description>Technology Compatibility Kit for Jakarta RESTful Web Services</description>
     <url>https://github.com/jakartaee/rest</url>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
 
     <parent>
         <groupId>jakarta.ws.rs</groupId>

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.jersey.core</groupId>
     <artifactId>jersey-tck</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <packaging>jar</packaging>
 
     <parent>


### PR DESCRIPTION
This is to append the tck versions from 3.1.1 to 3.1.2 for a new service release.

Requesting fast-track review on this as the changes involved only in tck and new service release is expected soon.

cc @jansupol @spericas @jim-krueger 