### PR TITLE
Deprecating "APPLICATION/SVG+XML" for Removal

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/MediaType.java
@@ -88,13 +88,13 @@ public class MediaType {
     public static final String APPLICATION_SVG_XML = "application/svg+xml";
     /**
      * A {@link MediaType} constant representing {@value #APPLICATION_SVG_XML} media type.
-     */
-    public static final MediaType APPLICATION_SVG_XML_TYPE = new MediaType("application", "svg+xml");
-    /**
-     * A {@code String} constant representing {@value #APPLICATION_JSON} media type.
      * @deprecated since 4.0, use a custom {@code MediaType} instead. Will be removed in a future release of this API.
      */
     @Deprecated(forRemoval = true)
+    public static final MediaType APPLICATION_SVG_XML_TYPE = new MediaType("application", "svg+xml");
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_JSON} media type.
+     */
     public static final String APPLICATION_JSON = "application/json";
     /**
      * A {@link MediaType} constant representing {@value #APPLICATION_JSON} media type.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/MediaType.java
@@ -82,7 +82,9 @@ public class MediaType {
     public static final MediaType APPLICATION_XHTML_XML_TYPE = new MediaType("application", "xhtml+xml");
     /**
      * A {@code String} constant representing {@value #APPLICATION_SVG_XML} media type.
+     * @deprecated since 4.0, use a custom string instead. Will be removed in a future release of this API.
      */
+    @Deprecated(forRemoval = true)
     public static final String APPLICATION_SVG_XML = "application/svg+xml";
     /**
      * A {@link MediaType} constant representing {@value #APPLICATION_SVG_XML} media type.
@@ -90,7 +92,9 @@ public class MediaType {
     public static final MediaType APPLICATION_SVG_XML_TYPE = new MediaType("application", "svg+xml");
     /**
      * A {@code String} constant representing {@value #APPLICATION_JSON} media type.
+     * @deprecated since 4.0, use a custom {@code MediaType} instead. Will be removed in a future release of this API.
      */
+    @Deprecated(forRemoval = true)
     public static final String APPLICATION_JSON = "application/json";
     /**
      * A {@link MediaType} constant representing {@value #APPLICATION_JSON} media type.


### PR DESCRIPTION
`APPLICATION/SVG+XML` is not recognized by modern browsers, as the official MIME type of SVG graphics is `IMAGE/SVG+XML`.

As least RESTful applications produce SVG at all, it makes not much sense to keep this and add the new variant. Instead, a custom String or a custom library should replace the outdated elements.