### PR TITLE
Can specify separation character for getHeaderString

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -184,14 +184,37 @@ public interface ClientRequestContext {
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
+     * This is a convenience method for {@code getHeaderString(name, ",")}.
+     *
      * @param name the message header.
      * @return the message header value. If the message header is not present then {@code null} is returned. If the message
      * header is present but has no value then the empty string is returned. If the message header is present more than once
      * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      * @see #getStringHeaders()
+     * @see #getHeaderString(String, String)
      */
-    public String getHeaderString(String name);
+    public default String getHeaderString(String name) {
+        return getHeaderString(name, ",");
+    }
+
+    /**
+     * Get a message header as a single string value.
+     *
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * @param name the message header.
+     * @param separator the separation character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by the provided separation character.
+     * @see #getHeaders()
+     * @see #getStringHeaders()
+     * @since 4.0
+     */
+    public String getHeaderString(String name, String separator);
 
     /**
      * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseContext.java
@@ -81,13 +81,31 @@ public interface ClientResponseContext {
     /**
      * Get a message header as a single string value.
      *
+     * This is a convenience method for {@code getHeaderString(name, ",")}.
+     *
      * @param name the message header.
      * @return the message header value. If the message header is not present then {@code null} is returned. If the message
      * header is present but has no value then the empty string is returned. If the message header is present more than once
      * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
+     * @see #getHeaderString(String, String)
      */
-    public String getHeaderString(String name);
+    public default String getHeaderString(String name) {
+        return getHeaderString(name, ",");
+    }
+
+    /**
+     * Get a message header as a single string value.
+     *
+     * @param name the message header.
+     * @param separator the separation character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by the provided separation character.
+     * @see #getHeaders()
+     * @since 4.0
+     */
+    public String getHeaderString(String name, String separator);
 
     /**
      * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -221,13 +221,31 @@ public interface ContainerRequestContext {
     /**
      * Get a message header as a single string value.
      *
+     * This is a convenience method for {@code getHeaderString(name, ",")}.
+     *
      * @param name the message header.
      * @return the message header value. If the message header is not present then {@code null} is returned. If the message
      * header is present but has no value then the empty string is returned. If the message header is present more than once
      * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
+     * @see #getHeaderString(String, String)
      */
-    public String getHeaderString(String name);
+    public default String getHeaderString(String name) {
+        return getHeaderString(name, ",");
+    }
+
+    /**
+     * Get a message header as a single string value.
+     *
+     * @param name the message header.
+     * @param separator the separation character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by the provided separation character.
+     * @see #getHeaders()
+     * @since 4.0
+     */
+    public String getHeaderString(String name, String separator);
 
     /**
      * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseContext.java
@@ -106,14 +106,37 @@ public interface ContainerResponseContext {
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
+     * This is a convenience method for {@code getHeaderString(name, ",")}.
+     *
      * @param name the message header.
      * @return the message header value. If the message header is not present then {@code null} is returned. If the message
      * header is present but has no value then the empty string is returned. If the message header is present more than once
      * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      * @see #getStringHeaders()
+     * @see #getHeaderString(String, String)
      */
-    public String getHeaderString(String name);
+    public default String getHeaderString(String name) {
+        return getHeaderString(name, ",");
+    }
+
+    /**
+     * Get a message header as a single string value.
+     *
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * @param name the message header.
+     * @param separator the separation character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by the provided separation character.
+     * @see #getHeaders()
+     * @see #getStringHeaders()
+     * @since 4.0
+     */
+    public String getHeaderString(String name, String separator);
 
     /**
      * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -52,6 +52,8 @@ public interface HttpHeaders {
      * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
      * class or using its {@code toString} method if a header delegate is not available.
      *
+     * This is a convenience method for {@code getHeaderString(name, ",")}.
+     *
      * @param name the HTTP header.
      * @return the HTTP header value. If the HTTP header is not present then {@code null} is returned. If the HTTP header is
      * present but has no value then the empty string is returned. If the HTTP header is present more than once then the
@@ -59,7 +61,27 @@ public interface HttpHeaders {
      * @see #getRequestHeader(java.lang.String)
      * @since 2.0
      */
-    public String getHeaderString(String name);
+    public default String getHeaderString(String name) {
+        return getHeaderString(name, ",");
+    }
+
+    /**
+     * <p>
+     * Get a HTTP header as a single string value.
+     * </p>
+     * Each single non-string header value is converted to String using a {@link jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link jakarta.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
+     *
+     * @param name the HTTP header.
+     * @param separator the separation character.
+     * @return the HTTP header value. If the HTTP header is not present then {@code null} is returned. If the HTTP header is
+     * present but has no value then the empty string is returned. If the HTTP header is present more than once then the
+     * values of joined together and separated by the provided separation character.
+     * @see #getRequestHeader(java.lang.String)
+     * @since 4.0
+     */
+    public String getHeaderString(String name, String separator);
 
     /**
      * Checks whether a header with a specific name and value (or item of the token-separated value list) exists.


### PR DESCRIPTION
In [an earlier discussion](https://github.com/jakartaee/rest/pull/1066#issuecomment-1249264250) @jansupol and me proposed to allow specifying the separation character for getHeaderString, as some header values actually may contain commas, so being able to separate them later bears the need to have non-comma separation.