### PR TITLE
TCK challenge : exclude getNormalizedUriTest

### DIFF
--- a/jaxrs-tck-docs/TCK-Exclude-List.txt
+++ b/jaxrs-tck-docs/TCK-Exclude-List.txt
@@ -152,3 +152,6 @@ ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithStr
 ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithResponseClassTest
 ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithGenericTypeStringTest
 ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithGenericTypeResponseTest
+
+https://github.com/jakartaee/rest/issues/1138
+ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT#getNormalizedUriTest

--- a/jaxrs-tck-docs/tckbundle.sh
+++ b/jaxrs-tck-docs/tckbundle.sh
@@ -23,7 +23,7 @@ cd $WORKSPACE
 export VERSION="$2"
 
 if [ -z "$VERSION" ]; then
-  export VERSION="3.1.2"
+  export VERSION="3.1.3"
 fi
 
 if [[ "$1" == "epl" || "$1" == "EPL" ]]; then

--- a/jaxrs-tck-docs/userguide/pom.xml
+++ b/jaxrs-tck-docs/userguide/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>tck_jaxrs</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta RESTful Web Services for Jakarta EE, Release 3.1</name>
 
     <properties>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -26,7 +26,7 @@
     <name>Jakarta RESTful WS TCK</name>
     <description>Technology Compatibility Kit for Jakarta RESTful Web Services</description>
     <url>https://github.com/jakartaee/rest</url>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
 
     <parent>
         <groupId>jakarta.ws.rs</groupId>

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 
 /*
  * @class.setup_props: webServerHost;
@@ -414,6 +415,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * obtained from an injected UriInfo
    */
   @Test
+  @Disabled
   public void getNormalizedUriTest() throws Fault {
     setProperty(Property.REQUEST, buildRequest(GET, URIInfoTest.DECODED));
     invoke();

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.jersey.core</groupId>
     <artifactId>jersey-tck</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <packaging>jar</packaging>
 
     <parent>


### PR DESCRIPTION
Resolves https://github.com/jakartaee/rest/issues/1138 by excluding the test.

This change would be part of the next Jakarta REST TCK maintenance release 3.1.3. 

Update: Added commit to append the TCK version to 3.1.3

Requesting fast-track review on this as the changes involved only in tck and new service release is expected for certifying OpenLiberty.


cc @arjantijms @jansupol @spericas @brideck 
