### PR TITLE
Compiling for Java 21

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '21-ea' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 		pollSCM('H H * * *')
 	}
 	tools {
-		jdk 'openjdk-jdk11-latest'
+		jdk 'openjdk-jdk21-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     </scm>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <apidocs.title>Jakarta RESTful Web Services ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <legal.doc.folder>${project.basedir}</legal.doc.folder>
@@ -168,8 +168,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>17</source>
-                        <target>17</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixes #1167

This PR enables compilation of JDK 21 in the release-4.0 branch as proposed in the discussion of https://github.com/jakartaee/rest/issues/1167.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**