### PR TITLE
Asciidoctor Update

### DIFF
--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -34,7 +34,7 @@
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.1</asciidoctorj.version>
+        <asciidoctorj.version>2.5.10</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <jruby.version>9.2.19.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -35,7 +35,7 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.10</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
         <jruby.version>9.2.19.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <jruby.version>9.2.19.0</jruby.version>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -36,7 +36,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.10</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
-        <jruby.version>9.2.19.0</jruby.version>
+        <jruby.version>9.4.0.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>


### PR DESCRIPTION
This PR updates Asciidoctor to the latest version.

*Note: This PR deliberately does not touch the versions used by the TCK. The reason is that (apparently) the TCK is using other versions. Before aligning the version numbers we need to take care the TCK is fine with them. Hence that goes in a subsequent PR.*

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**