### PR TITLE
Jakarta REST 4.0 Epic: Updating top-level files

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -3,9 +3,9 @@ name: Jakarta REST CI
 
 on:
   push:
-    branches: [ master, 4.0-SNAPSHOT ]
+    branches: [ master, release-4.0 ]
   pull_request:
-    branches: [ master, 4.0-SNAPSHOT ]
+    branches: [ master, release-4.0 ]
 
 jobs:
   build:


### PR DESCRIPTION
This issue resolved the item "Update README, LICENSE and review all other top-level files" from the Jakarta REST 4.0 Epic.

In fact, all top-level files look good and do not need any changes justified by switching from 3.1 to 4.0 (some other changes might be useful but should go into `master`, or are covered by other PRs already).

The sole change is the correction of the used branch name.