### PR TITLE
Replaced GitHub URL from eclipse-ee4j to jakartaee namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ more.
 
 The project maintains the following source code repositories
 
-* https://github.com/eclipse-ee4j/jaxrs-api
+* https://github.com/jakartaee/rest
 
 ## Eclipse Contributor Agreement
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -31,7 +31,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse-ee4j/jaxrs-api
+* https://github.com/jakartaee/rest
 
 ## Third-party Content
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/CacheControl.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/CacheControl.java
@@ -36,7 +36,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 public class CacheControl {
 
     /**
-     * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
+     * @deprecated This field will be removed in a future version. See https://github.com/jakartaee/rest/issues/607
      */
     @Deprecated
     private static final HeaderDelegate<CacheControl> HEADER_DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class);

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Cookie.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Cookie.java
@@ -35,7 +35,7 @@ public class Cookie {
      */
     public static final int DEFAULT_VERSION = 1;
     /**
-     * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
+     * @deprecated This field will be removed in a future version. See https://github.com/jakartaee/rest/issues/607
      */
     @Deprecated
     private static final HeaderDelegate<Cookie> HEADER_DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class);

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/EntityTag.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/EntityTag.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
  */
 public class EntityTag {
     /**
-     * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
+     * @deprecated This field will be removed in a future version. See https://github.com/jakartaee/rest/issues/607
      */
     @Deprecated
     private static final HeaderDelegate<EntityTag> HEADER_DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class);

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/NewCookie.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/NewCookie.java
@@ -37,7 +37,7 @@ public class NewCookie extends Cookie {
     public static final int DEFAULT_MAX_AGE = -1;
 
     /**
-     * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
+     * @deprecated This field will be removed in a future version. See https://github.com/jakartaee/rest/issues/607
      */
     @Deprecated
     private static final HeaderDelegate<NewCookie> DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class);

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -45,14 +45,14 @@
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</connection>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
+        <connection>scm:git:https://github.com/jakartaee/rest</connection>
+        <url>https://github.com/jakartaee/rest</url>
         <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>
         <site>
-            <url>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</url>
+            <url>scm:git:https://github.com/jakartaee/rest</url>
         </site>
     </distributionManagement>
 

--- a/jaxrs-spec/src/main/asciidoc/chapters/introduction/_status.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/introduction/_status.adoc
@@ -14,7 +14,7 @@
 This is the final release of version 3.1. The issue tracking system for
 this release can be found at:
 
-https://github.com/eclipse-ee4j/jaxrs-api/issues
+https://github.com/jakartaee/rest/issues
 
 The corresponding Javadocs can be found online at:
 

--- a/jaxrs-spec/src/main/asciidoc/spec.adoc
+++ b/jaxrs-spec/src/main/asciidoc/spec.adoc
@@ -9,7 +9,7 @@
 ////
 
 = Jakarta RESTful Web Services
-:authors: Contributors to Jakarta RESTful Web Services (https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors)
+:authors: Contributors to Jakarta RESTful Web Services (https://github.com/jakartaee/rest/graphs/contributors)
 :email: jaxrs-dev@eclipse.org
 :version-label!:
 :doctype: book

--- a/jaxrs-tck-docs/userguide/pom.xml
+++ b/jaxrs-tck-docs/userguide/pom.xml
@@ -48,7 +48,7 @@
 
     <distributionManagement>
         <site>
-            <url>scm:git:git@github.com:eclipse-ee4j/jaxrs-api.git</url>
+            <url>scm:git:git@github.com:jakartaee/rest.git</url>
         </site>
     </distributionManagement>
 

--- a/jaxrs-tck-docs/userguide/src/main/jbake/assets/_config.yml
+++ b/jaxrs-tck-docs/userguide/src/main/jbake/assets/_config.yml
@@ -6,7 +6,7 @@ description: [Oracle Technology Compatibility Kit User's Guide for Jakarta RESTf
 
 # sidebar links url
 links:
-  source: https://github.com/eclipse-ee4j/jaxrs-api
+  source: https://github.com/jakartaee/rest
   download: https://jakarta.ee/specifications/restful-ws/3.1/
   #mailinglist: https://javaee.groups.io/g/tck_jaxrs_v2_1
   #javadocs:

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -51,13 +51,13 @@
             <id>developers</id>
             <name>JAX-RS API Developers</name>
             <email>jaxrs-dev@eclipse.org</email>
-            <url>https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors</url>
+            <url>https://github.com/jakartaee/rest/graphs/contributors</url>
         </developer>
     </developers>
 
     <issueManagement>
         <system>Github</system>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api/issues</url>
+        <url>https://github.com/jakartaee/rest/issues</url>
     </issueManagement>
 
     <mailingLists>
@@ -81,8 +81,8 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</connection>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
+        <connection>scm:git:https://github.com/jakartaee/rest</connection>
+        <url>https://github.com/jakartaee/rest</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
+    <url>https://github.com/jakartaee/rest</url>
 
     <organization>
         <name>Eclipse Foundation</name>
@@ -47,13 +47,13 @@
             <id>developers</id>
             <name>JAX-RS API Developers</name>
             <email>jaxrs-dev@eclipse.org</email>
-            <url>https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors</url>
+            <url>https://github.com/jakartaee/rest/graphs/contributors</url>
         </developer>
     </developers>
 
     <issueManagement>
         <system>Github</system>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api/issues</url>
+        <url>https://github.com/jakartaee/rest/issues</url>
     </issueManagement>
 
     <mailingLists>
@@ -77,8 +77,8 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</connection>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
+        <connection>scm:git:https://github.com/jakartaee/rest</connection>
+        <url>https://github.com/jakartaee/rest</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
Merging https://github.com/jakartaee/rest/pull/1175 into `release-4.0` branch.

Apparently committers cannot push the same changes *directly*...

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**
