### PR TITLE
TCK challenge: exclude setEntityStreamTest

### DIFF
--- a/jaxrs-tck-docs/TCK-Exclude-List.txt
+++ b/jaxrs-tck-docs/TCK-Exclude-List.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -155,3 +155,6 @@ ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithGen
 
 https://github.com/jakartaee/rest/issues/1138
 ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT#getNormalizedUriTest
+
+https://github.com/jakartaee/rest/issues/1163
+ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT#setEntityStreamTest

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 
 /*
  * @class.setup_props: webServerHost;
@@ -1103,6 +1104,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * Throws IOException.
    */
   @Test
+  @Disabled
   public void setEntityStreamTest() throws Fault {
     setProperty(Property.SEARCH_STRING, ResponseFilter.ENTITY);
     setProperty(Property.SEARCH_STRING, "OK");


### PR DESCRIPTION
Resolves https://github.com/jakartaee/rest/issues/1163 by excluding the test.

This change would be part of the next Jakarta REST TCK maintenance release 3.1.4.

Requesting fast-track review on this as the changes made only in tck.

cc @jansupol @spericas @radcortez @jamezp 