### PR TITLE
fast-track: 1162 sse broadcast test

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.ssebroadcaster;
 
 import java.util.List;
+import java.util.ArrayList;
 import java.io.InputStream;
 import java.io.IOException;
 


### PR DESCRIPTION
When moving fix from test system for #1172 I missed an import and for some reason the maven build done as part of the checks did not flag this.  This PR adds the missing import.