### PR TITLE
[gh-pages] Fixes for apidoc references and compatibility with JDK 1.8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,9 +6,8 @@ description: [Jakarta RESTful Web Services provides a specification document, TC
 latestVersion: 3.0.0
 
 links:
-  source: https://github.com/eclipse-ee4j/jaxrs-api
-  javadocs: https://eclipse-ee4j.github.io/jaxrs-api/apidocs
+  source: https://github.com/jakartaee/rest
+  javadocs: https://jakartaee.github.io/rest/apidocs
   docs: https://jakarta.ee/specifications/restful-ws/3.0/jakarta-restful-ws-spec-3.0.html
-  download: https://github.com/eclipse-ee4j/jaxrs-api/releases
+  download: https://github.com/jakartaee/rest/releases
   mailinglist: https://accounts.eclipse.org/mailing-list/jaxrs-dev
-

--- a/apidocs/2.1.6/package-list
+++ b/apidocs/2.1.6/package-list
@@ -1,0 +1,6 @@
+javax.ws.rs
+javax.ws.rs.client
+javax.ws.rs.container
+javax.ws.rs.core
+javax.ws.rs.ext
+javax.ws.rs.sse

--- a/apidocs/3.0.0/package-list
+++ b/apidocs/3.0.0/package-list
@@ -1,0 +1,6 @@
+jakarta.ws.rs
+jakarta.ws.rs.client
+jakarta.ws.rs.container
+jakarta.ws.rs.core
+jakarta.ws.rs.ext
+jakarta.ws.rs.sse

--- a/apidocs/index.md
+++ b/apidocs/index.md
@@ -2,6 +2,6 @@
 
 ## Current Version
 
-* [Jakarta RESTful Web Services 3.0.0](/jaxrs-api/apidocs/3.0.0/)
+* [Jakarta RESTful Web Services 3.0.0](/rest/apidocs/3.0.0/)
 
-* [Jakarta RESTful Web Services 2.1.6](/jaxrs-api/apidocs/2.1.6/)
+* [Jakarta RESTful Web Services 2.1.6](/rest/apidocs/2.1.6/)


### PR DESCRIPTION
PR provides fixes on links to API docs and makes released API docs compatible with references from documentations compiled with JDKs prior to JDK 10. 

As soon as this is only a documentation change (which, however, affects the functionality of the page) I apply for fast-track merging into the gh-pages branch. 