### PR TITLE
TCK Challenge: JAXRSClientIT#closeTest fixes #1196

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 .classpath
+.factorypath
 .project
 .settings/
 *.iml

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -633,8 +633,6 @@ public class JAXRSClientIT extends SSEJAXRSClient {
     source.open();
     sleepUntilHolderGetsFilled(holder);
     assertNotNull(holder.get(), "Message was not received");
-    for (InboundSseEvent e : holder)
-      logMsg("Received message no", e.readData());
 
     // check the session is opened
     setProperty(Property.REQUEST, buildRequest(Request.GET, "repeat/isopen"));
@@ -646,8 +644,6 @@ public class JAXRSClientIT extends SSEJAXRSClient {
     for (int i = 0; i != 3; i++) {
       holder.clear();
       sleepUntilHolderGetsFilled(holder);
-      for (InboundSseEvent e : holder)
-        logMsg("Received message no", e.readData());
     }
     // close
     source.close();

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/RepeatedCasterResource.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/RepeatedCasterResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,10 +54,10 @@ public class RepeatedCasterResource {
           isOpen = !sink.isClosed();
         }
         while (!sink.isClosed() && cast) {
-          sink.send(sse.newEvent(String.valueOf(cnt++)));
           try {
-            Thread.sleep(500L);
-          } catch (InterruptedException e1) {
+            sink.send(sse.newEvent(String.valueOf(cnt++)));
+            Thread.sleep(1L);
+          } catch (Exception e1) {
             cast = false;
           }
           synchronized (isOpen) {


### PR DESCRIPTION
Relates to https://github.com/jakartaee/rest/issues/1196

It also increased the frequency that events are sent back. I had a problem in Helidon that it took longer than the test expects to be aware of the closed stream.

This is the stacktrace when the exception is thrown:

```
, ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsource.RepeatedCasterResource$1.run(RepeatedCasterResource.java:58)]
, org.glassfish.jersey.media.sse.internal.JerseyEventSink.send(JerseyEventSink.java:140)
, org.glassfish.jersey.server.ChunkedOutput.write(ChunkedOutput.java:184)
, org.glassfish.jersey.server.ChunkedOutput.flushQueue(ChunkedOutput.java:198)
, org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:314)
, org.glassfish.jersey.internal.Errors.process(Errors.java:219)
, org.glassfish.jersey.internal.Errors.process(Errors.java:292)
, org.glassfish.jersey.server.ChunkedOutput$1.call(ChunkedOutput.java:198)
, org.glassfish.jersey.server.ChunkedOutput$1.call(ChunkedOutput.java:231)
, org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1116)
, org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
, org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.aroundWriteTo(WriterInterceptorExecutor.java:227)
, org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.invokeWriteTo(WriterInterceptorExecutor.java:242)
, org.glassfish.jersey.media.sse.OutboundEventWriter.writeTo(OutboundEventWriter.java:44)
, org.glassfish.jersey.media.sse.OutboundEventWriter.writeTo(OutboundEventWriter.java:118)
, org.glassfish.jersey.message.internal.StringMessageProvider.writeTo(StringMessageProvider.java:36)
, org.glassfish.jersey.message.internal.StringMessageProvider.writeTo(StringMessageProvider.java:76)
, org.glassfish.jersey.message.internal.AbstractMessageReaderWriterProvider.writeToAsString(AbstractMessageReaderWriterProvider.java:107)
, org.glassfish.jersey.message.internal.ReaderWriter.writeToAsString(ReaderWriter.java:247)
, java.base/java.io.OutputStreamWriter.flush(OutputStreamWriter.java:262)
, java.base/sun.nio.cs.StreamEncoder.flush(StreamEncoder.java:201)
, java.base/sun.nio.cs.StreamEncoder.lockedFlush(StreamEncoder.java:214)
, java.base/sun.nio.cs.StreamEncoder.implFlush(StreamEncoder.java:410)
, java.base/sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:405)
, java.base/sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:309)
, java.base/java.io.OutputStream.write(OutputStream.java:167)
, org.glassfish.jersey.media.sse.OutboundEventWriter$1.write(OutboundEventWriter.java:132)
, org.glassfish.jersey.message.internal.WriterInterceptorExecutor$UnCloseableOutputStream.write(WriterInterceptorExecutor.java:271)
, org.glassfish.jersey.message.internal.CommittingOutputStream.write(CommittingOutputStream.java:185)
, io.helidon.microprofile.server.JaxRsService$NoFlushOutputStream.write(JaxRsService.java:402)
, java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:110)
, java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:206)
, java.base/java.io.BufferedOutputStream.implWrite(BufferedOutputStream.java:222)
, java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:125)
, io.helidon.webserver.http1.Http1ServerResponse$BlockingOutputStream.write(Http1ServerResponse.java:439)
, io.helidon.webserver.http1.Http1ServerResponse$BlockingOutputStream.write(Http1ServerResponse.java:591)
, io.helidon.webserver.http1.Http1ServerResponse$BlockingOutputStream.writeChunked(Http1ServerResponse.java:665)
, io.helidon.common.socket.SocketWriterDirect.write(SocketWriterDirect.java:43)
, io.helidon.common.socket.SocketWriter.writeNow(SocketWriter.java:77)
, io.helidon.common.socket.PlainSocket.write(PlainSocket.java:136)
, io.helidon.common.buffers.FixedBufferData.writeTo(FixedBufferData.java:71)
, java.base/java.net.Socket$SocketOutputStream.write(Socket.java:1195)
, java.base/sun.nio.ch.NioSocketImpl$2.write(NioSocketImpl.java:819)
, java.base/sun.nio.ch.NioSocketImpl.write(NioSocketImpl.java:440)
, java.base/sun.nio.ch.NioSocketImpl.implWrite(NioSocketImpl.java:410)
, java.base/sun.nio.ch.NioSocketImpl.tryWrite(NioSocketImpl.java:394)
, java.base/sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:62)
[java.base/sun.nio.ch.SocketDispatcher.write0(Native Method)
```