### PR TITLE
Add the enforcer plugin and require a minimum of Java 21 to compile t…

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '21-ea' ]
+        java: [ '17', '21' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -35,7 +35,8 @@
     </parent>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <!-- Explicitly set the release level to Java SE 17 -->
+        <maven.compiler.release>17</maven.compiler.release>
         <junit.jupiter.version>[5.7.2, 5.8-A00)</junit.jupiter.version>
         <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
     </properties>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -35,8 +35,7 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <junit.jupiter.version>[5.7.2, 5.8-A00)</junit.jupiter.version>
         <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
     </properties>
@@ -125,7 +124,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>2.3.2</version>
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -133,7 +131,6 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-jar-plugin</artifactId>
-                        <version>3.2.0</version>
                     </plugin>
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,10 @@
     </scm>
 
     <properties>
-        <java.version>21</java.version>
+        <!-- Used in the enforcer plugin to require the minimum Java version -->
+        <jdk.min.version>21</jdk.min.version>
+        <!-- used in the compiler plugin for the release level -->
+        <maven.compiler.release>17</maven.compiler.release>
 
         <apidocs.title>Jakarta RESTful Web Services ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <legal.doc.folder>${project.basedir}</legal.doc.folder>
@@ -174,10 +177,6 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.plugin.version}</version>
-                    <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
@@ -352,6 +351,28 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <message>To build this project JDK ${jdk.min.version} (or greater) is required.</message>
+                                    <version>${jdk.min.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
     <properties>
         <!-- Used in the enforcer plugin to require the minimum Java version -->
-        <jdk.min.version>21</jdk.min.version>
+        <jdk.min.version>17</jdk.min.version>
         <!-- used in the compiler plugin for the release level -->
         <maven.compiler.release>17</maven.compiler.release>
 


### PR DESCRIPTION
The minimum level should remain at Java SE 17. The TCK itself should also require Java SE 17 as a minimum.

resolves #1202 