### PR TITLE
Deprecate both @Context and @Suspended

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -3,9 +3,9 @@ name: Jakarta REST CI
 
 on:
   push:
-    branches: [ '3.2.0-SNAPSHOT' ]
+    branches: [ 'release-3.2' ]
   pull_request:
-    branches: [ '3.2.0-SNAPSHOT' ]
+    branches: [ 'release-3.2' ]
 
 jobs:
   build:

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/Suspended.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/Suspended.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Marek Potociar
  * @since 2.0
+ * @deprecated This class will be removed in a future version.  Better align with Jakarta CDI.
  */
+@Deprecated(forRemoval = true)
 @Target({ ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Context.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,7 +38,9 @@ import java.lang.annotation.Target;
  * @see SecurityContext
  * @see jakarta.ws.rs.ext.Providers
  * @since 1.0
+ * @deprecated This class will be removed in a future version.  Better align with Jakarta CDI.
  */
+@Deprecated(forRemoval = true)
 @Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented


### PR DESCRIPTION
Deprecate `@Context` and `@Suspended` in release-3.2 in preparation for removal in release-4.0