### PR TITLE
Version changes for TCK service release 3.1.5

### DIFF
--- a/jaxrs-tck-docs/TCK-Exclude-List.txt
+++ b/jaxrs-tck-docs/TCK-Exclude-List.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -156,8 +156,12 @@ ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithRes
 ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithGenericTypeStringTest
 ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java#traceWithGenericTypeResponseTest
 
-https://github.com/jakartaee/rest/issues/1138
+# https://github.com/jakartaee/rest/issues/1138
 ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT#getNormalizedUriTest
 
-https://github.com/jakartaee/rest/issues/1163
+# https://github.com/jakartaee/rest/issues/1163
 ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT#setEntityStreamTest
+
+# https://github.com/jakartaee/rest/issues/1199
+ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT#setStatusTest
+ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT#setStatusInfoTest

--- a/jaxrs-tck-docs/tckbundle.sh
+++ b/jaxrs-tck-docs/tckbundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck-docs/tckbundle.sh
+++ b/jaxrs-tck-docs/tckbundle.sh
@@ -23,7 +23,7 @@ cd $WORKSPACE
 export VERSION="$2"
 
 if [ -z "$VERSION" ]; then
-  export VERSION="3.1.4"
+  export VERSION="3.1.5"
 fi
 
 if [[ "$1" == "epl" || "$1" == "EPL" ]]; then

--- a/jaxrs-tck-docs/userguide/pom.xml
+++ b/jaxrs-tck-docs/userguide/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>tck_jaxrs</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta RESTful Web Services for Jakarta EE, Release 3.1</name>
 
     <properties>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-    Copyright (c) 2023 Markus Karg. All rights reserved.
+    Copyright (c) 2023, 2024 Markus Karg. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
     <name>Jakarta RESTful WS TCK</name>
     <description>Technology Compatibility Kit for Jakarta RESTful Web Services</description>
     <url>https://github.com/jakartaee/rest</url>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
 
     <parent>
         <groupId>jakarta.ws.rs</groupId>

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.jersey.core</groupId>
     <artifactId>jersey-tck</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <packaging>jar</packaging>
 
     <parent>


### PR DESCRIPTION
This is to append the tck version to 3.1.5 for a new service release. 

The updates are to exclude the challenged tests as in PR https://github.com/jakartaee/rest/issues/1200.

Requesting fast-track review on this as the changes involved only in tck.

cc @jansupol @spericas 