### PR TITLE
fast track: Port missed fixes that were in release-4.0

### DIFF
--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -33,9 +33,7 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctorj.version>2.5.1</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
-        <jruby.version>9.2.19.0</jruby.version>
+        <jruby.version>9.4.6.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -49,6 +47,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctorj.maven.plugin.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>

--- a/jaxrs-tck-docs/userguide/pom.xml
+++ b/jaxrs-tck-docs/userguide/pom.xml
@@ -34,10 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctorj.version>2.4.2</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.1.0</asciidoctorj.diagram.version>
-        <asciidoctorj.maven.plugin.version>2.1.0</asciidoctorj.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jbake.maven.plugin.version>0.3.3</jbake.maven.plugin.version>
         <freemarker.version>2.3.30</freemarker.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
@@ -137,11 +134,11 @@
                 <configuration>
                     <sourceDirectory>${project.build.directory}/book</sourceDirectory>
                     <sourceDocumentName>book.adoc</sourceDocumentName>
-                    <!-- XXX - below depends on running jbake first -->
-                    <imagesDir>${project.build.directory}/staging/</imagesDir>
                     <backend>pdf</backend>
                     <outputFile>${doc.pdf}</outputFile>
                     <attributes>
+                        <!-- XXX - below depends on running jbake first -->
+                        <imagesdir>${project.build.directory}/staging/</imagesdir>
                         <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                         <pdf-style>jakartaee</pdf-style>
                         <doctype>book</doctype>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -119,14 +119,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
             <name>JAX-RS API Repository - Snapshots</name>
             <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
         </snapshotRepository>
-    </distributionManagement><url>https://github.com/eclipse-ee4j/jaxrs-api</url>
+    </distributionManagement><url>https://github.com/jakartaee/rest</url>
 
     <organization>
         <name>Eclipse Foundation</name>
@@ -46,13 +46,13 @@
             <id>developers</id>
             <name>JAX-RS API Developers</name>
             <email>jaxrs-dev@eclipse.org</email>
-            <url>https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors</url>
+            <url>https://github.com/jakartaee/rest/graphs/contributors</url>
         </developer>
     </developers>
 
     <issueManagement>
         <system>Github</system>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api/issues</url>
+        <url>https://github.com/jakartaee/rest/issues</url>
     </issueManagement>
 
     <mailingLists>
@@ -76,8 +76,8 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</connection>
-        <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
+        <connection>scm:git:https://github.com/jakartaee/rest</connection>
+        <url>https://github.com/jakartaee/rest</url>
         <tag>HEAD</tag>
     </scm>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
         <com.sun.istack.version>4.1.2</com.sun.istack.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.6.0</mockito.version>
+
+        <!-- Documentation versions -->
+        <asciidoctorj.maven.plugin.version>3.0.0</asciidoctorj.maven.plugin.version>
+        <asciidoctorj.version>2.5.11</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.3.13</asciidoctorj.pdf.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,17 @@
         <apidocs.title>Jakarta RESTful Web Services ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <legal.doc.folder>${project.basedir}</legal.doc.folder>
 
-        <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
+        <build.helper.maven.plugin.version>3.5.0</build.helper.maven.plugin.version>
+        <buildernumber.maven.plugin.version>3.2.0</buildernumber.maven.plugin.version>
+        <glassfish.copyright.maven.plugin.version>2.4</glassfish.copyright.maven.plugin.version>
+        <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
+        <maven.checkstyle.plugin.version>3.3.1</maven.checkstyle.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
+        <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
+        <maven.jxr.plugin.version>3.3.2</maven.jxr.plugin.version>
+        <maven.javadoc.plugin.version>3.6.3</maven.javadoc.plugin.version>
+        <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
+        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
 
         <api.package>jakarta.ws.rs</api.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -104,11 +112,11 @@
         <concurrent.api.version>2.0.0</concurrent.api.version>
         <xml.binding.api.version>4.0.0</xml.binding.api.version>
         <cdi.api.version>3.0.0</cdi.api.version>
-        <junit.version>5.8.2</junit.version>
+        <junit.version>5.10.2</junit.version>
         <org.glassfish.jaxb.version>4.0.3</org.glassfish.jaxb.version>
         <com.sun.istack.version>4.1.2</com.sun.istack.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <mockito.version>3.6.0</mockito.version>
+        <mockito.version>5.11.0</mockito.version>
 
         <!-- Documentation versions -->
         <asciidoctorj.maven.plugin.version>3.0.0</asciidoctorj.maven.plugin.version>
@@ -308,20 +316,20 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>${maven.compiler.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>${maven.jar.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>${maven.surefire.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>${buildernumber.maven.plugin.version}</version>
                     <configuration>
                         <format>{0,date,MM/dd/yyyy hh:mm aa}</format>
                         <items>
@@ -395,7 +403,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>${maven.source.plugin.version}</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -408,7 +416,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>${build.helper.maven.plugin.version}</version>
                     <executions>
                         <execution>
                             <id>add-legal-resource</id>
@@ -433,7 +441,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jxr-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>${maven.jxr.plugin.version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -445,7 +453,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>${maven.checkstyle.plugin.version}</version>
                     <configuration>
                         <outputDirectory>${project.build.directory}/checkstyle</outputDirectory>
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
@@ -464,7 +472,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.39</version>
+                    <version>${glassfish.copyright.maven.plugin.version}</version>
                     <configuration>
                         <excludeFile>${basedir}/../etc/config/copyright-exclude</excludeFile>
                         <!--svn|mercurial|git - defaults to svn-->


### PR DESCRIPTION
I found these commits I missed that were in release-4.0 and not in main or release-3.2. 

---

###  GItHub Links
The first commit is to fix a bad port which reverted some changes from #1177 

### Asciidoctor Dependency Updates
These are from #1170 

### Maven Plugin Dependency Updates
This includes a JUnit and mockito upgrades as well. This is a port of #1169