### PR TITLE
fast-track: Add a TCK test to verify that the default ExceptionMapper can be overridden.

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/DefaultExceptionMapperIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/DefaultExceptionMapperIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import ee.jakarta.tck.ws.rs.common.JAXRSCommonClient;
+import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class DefaultExceptionMapperIT extends JAXRSCommonClient {
+
+  public DefaultExceptionMapperIT() {
+    setContextRoot("/jaxrs_resource_webappexception_defaultmapper_web/resource");
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = DefaultExceptionMapperIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/web.xml.template");
+    // Replace the servlet_adaptor in web.xml.template with the System variable set as servlet adaptor
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_resource_webappexception_defaultmapper_web.war");
+    archive.addClasses(
+        TSAppConfig.class, 
+        Resource.class, 
+        OverriddenDefaultExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    super.setup();
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: overrideDefaultExceptionMapperTest
+   * 
+   * @test_Strategy: The default ExceptionMapper must be able to be overridden.
+   */
+  @Test
+  public void overrideDefaultExceptionMapperTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "throwable"));
+    setProperty(STATUS_CODE, "512");
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/OverriddenDefaultExceptionMapper.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/OverriddenDefaultExceptionMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class OverriddenDefaultExceptionMapper implements ExceptionMapper<Throwable> {
+
+    /*
+     * 4.4. Exception Mapping Providers states:
+     * "A JAX-RS implementation MUST include a default exception mapping provider
+     * that implements ExceptionMapper<Throwable> and which SHOULD set the
+     * response status to 500."
+     * 
+     * This class should override the default ExceptionMapper and set the
+     * response status to 512 to verify that the default ExceptionMapper
+     * was overriden.
+     */
+  @Override
+  public Response toResponse(Throwable throwable) {
+    return Response.status(512).build();
+  }
+    
+}

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/Resource.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/Resource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("resource")
+public class Resource {
+
+  @GET
+  @Path("/throwable")
+  public Response throwable() throws Throwable {
+    throw new Throwable();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/TSAppConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    resources.add(OverriddenDefaultExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/resources/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/web.xml.template
+++ b/jaxrs-tck/src/main/resources/ee/jakarta/tck/ws/rs/ee/resource/webappexception/defaultmapper/web.xml.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTS_JAXRS_WEBAPPEXCEPTION_MAPPER</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTS_JAXRS_WEBAPPEXCEPTION_MAPPER</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>


### PR DESCRIPTION
The `nomapper` tests seem to test the default `ExceptionMapper`, however, we could use a test to verify that the default `ExceptionMapper` can be overridden.

This test overrides the default `ExceptionMapper` to return status HTTP 512 instead of HTTP 500 and the test client verifies that status HTTP 512 is returned.