### PR TITLE
[1239] Use the correct Variant constructor for the header content lan…

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/headers/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/headers/JAXRSClientIT.java
@@ -140,7 +140,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   public void contentLanguageTest() throws Fault {
     setProperty(Property.REQUEST_HEADERS,
         buildAccept(MediaType.TEXT_PLAIN_TYPE));
-    Variant variant = new Variant(MediaType.WILDCARD_TYPE, "en-US", null);
+    Variant variant = new Variant(MediaType.WILDCARD_TYPE, "en", "US", null);
     Entity<String> entity = Entity.entity("anything", variant);
     setRequestContentEntity(entity);
     setProperty(Property.REQUEST, buildRequest(Request.PUT, ""));


### PR DESCRIPTION
…guage TCK test.

resolves #1239 

This potentially may need to be back ported to 3.1 as well.