### PR TITLE
fast-track: Fix the including of resources in the TCK.

### DIFF
--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -113,7 +113,7 @@
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>LICENSE_${license}.md</include>
-                    <include>com/</include>
+                    <include>ee/</include>
                 </includes>
             </resource>
         </resources>


### PR DESCRIPTION
This was caused by #1224. Just a minor change from `com/` to `ee/` since the package name starts with `ee`.