### PR TITLE
TCK : Get hostname and port number injected using ArquillianResource url 

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/ext/interceptor/reader/interceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/ext/interceptor/reader/interceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,10 +50,6 @@ public class JAXRSClientIT extends ReaderClient<ContextOperation> {
 
   private static final long serialVersionUID = -8828149277776372718L;
 
-  public JAXRSClientIT() {
-    setup();
-  }
-
   @BeforeEach
   void logStartTest(TestInfo testInfo) {
     TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
@@ -62,6 +58,15 @@ public class JAXRSClientIT extends ReaderClient<ContextOperation> {
   @AfterEach
   void logFinishTest(TestInfo testInfo) {
     TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @BeforeEach
+  public void setup() {
+    // Only the values are verified, using verifySettings() in JaxrWebTestCase.java
+    // but the URL with these values is not required to work. 
+    // TODO: remove validation of these values for the tests in this file.
+    _hostname = "localhost";
+    _port = 8080;
   }
   
   /*

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/ext/interceptor/reader/readerinterceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/ext/interceptor/reader/readerinterceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,8 +38,18 @@ public class JAXRSClientIT extends ReaderClient<ContextOperation> {
 
   private static final long serialVersionUID = -6962070973647934636L;
 
-  public JAXRSClientIT() {
-    setup();
+  @BeforeEach
+  public void setup() {
+
+    // Only the values are verified, using verifySettings() in JaxrWebTestCase.java
+    // but the URL with these values is not required to work. 
+    // TODO: remove validation of these values for the tests in this file.
+    _hostname = "localhost";
+    _port = 8080;
+
+    String property = System.getProperty("cts.tmp", "/tmp");
+    if (property != null) 
+      System.setProperty("java.io.tmpdir", property);
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/common/JAXRSCommonClient.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/common/JAXRSCommonClient.java
@@ -18,6 +18,7 @@ package ee.jakarta.tck.ws.rs.common;
 
 import java.io.*;
 import java.net.InetAddress;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -35,6 +36,9 @@ import ee.jakarta.tck.ws.rs.common.webclient.validation.CheckOneOfStatusesTokeni
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpState;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -239,36 +243,29 @@ public abstract class JAXRSCommonClient {
     return _contextRoot;
   }
 
+  @ArquillianResource
+  @OperateOnDeployment("_DEFAULT_")
+  private URL url;
+  
   /**
-   * <code>setup</code> is by the test harness to initialize the tests.
+   * <code>setup</code> is run by the test files to initialize the tests.
    * 
-   * @param args
-   *          a <code>String[]</code> value
-   * @param p
-   *          a <code>Properties</code> value
-   * @exception Fault
-   *              if an error occurs
    */
-  //public void setup(String[] args, Properties p)   {
-  public void setup()   {
+  public void setup() {
+
     TestUtil.logTrace("setup method JAXRSCommonClient");
 
-    String hostname = System.getProperty(SERVLETHOSTPROP);
-    String portnum = System.getProperty(SERVLETPORTPROP);
-    //String tshome = p.getProperty(TSHOME);
-
-    assertTrue(!isNullOrEmpty(hostname),
-        "[JAXRSCommonClient] 'webServerHost' was not set.");
+    assertFalse((url==null), "[JAXRSCommonClient] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSCommonClient] 'webServerHost' was not set.");
     _hostname = hostname.trim();
-    assertTrue(!isNullOrEmpty(portnum),
-        "[JAXRSCommonClient] 'webServerPort' was not set.");
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSCommonClient] 'webServerPort' was not set.");
     _port = Integer.parseInt(portnum.trim());
-
-    //assertTrue(!isNullOrEmpty(tshome),
-    //    "[JAXRSCommonClient] 'tshome' was not set in the build.properties.");
-    //_tsHome = tshome.trim();
-
     TestUtil.logMsg("[JAXRSCommonClient] Test setup OK");
+
   }
 
   /**

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/java2entity/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/java2entity/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,8 +46,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_resource_java2entity_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/mapper/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/mapper/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,8 +44,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_resource_webappexception_mapper_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/nomapper/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/resource/webappexception/nomapper/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,8 +44,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_resource_webappexception_nomapper_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/BeanParamCommonClient.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/BeanParamCommonClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -158,7 +158,7 @@ public abstract class BeanParamCommonClient extends JaxrsParamClient {
           found = true;
     }
     assertTrue(found, "Could not find cookie" + cookie+ "in response headers:" +
-        JaxrsUtil.iterableToString(";", headers));
+        JaxrsUtil.iterableToString(";", (Object)headers));
     logMsg("Found cookie", cookie, "as expected");
   }
 

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/cookie/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/cookie/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,8 +62,12 @@ public class JAXRSClientIT extends BeanParamCommonClient {
   private static final long serialVersionUID = 201L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_cookie_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/form/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/form/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,8 +62,12 @@ public class JAXRSClientIT extends BeanParamCommonClient {
   private static final long serialVersionUID = 201L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_form_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/header/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/header/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,8 +62,12 @@ public class JAXRSClientIT extends BeanParamCommonClient {
   private static final long serialVersionUID = 201L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_header_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/matrix/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/matrix/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,8 +63,12 @@ public class JAXRSClientIT extends BeanParamCommonClient {
   private static final long serialVersionUID = 201L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_matrix_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/path/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/path/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,8 +61,12 @@ public class JAXRSClientIT extends BeanParamCommonClient {
   private static final long serialVersionUID = 201L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_path_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -81,8 +81,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final String TWELVENTH = "Twelveth";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/query/plain/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/beanparam/query/plain/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,8 +63,12 @@ public class JAXRSClientIT extends BeanParamCommonClient {
   private static final long serialVersionUID = 201L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_beanparam_query_plain_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/asyncinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/asyncinvoker/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,8 +71,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private final static String NONEXISTING_SITE = "somenonexisting.domain-site";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("jaxrs_ee_rs_client_asyncinvoker_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   static final String[] METHODS = { "DELETE", "GET", "OPTIONS" };

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/clientrequestcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/clientrequestcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,8 +55,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = -3234850442044177095L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_client_clientrequestcontext_web/resource");
+  }
+  
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/invocationbuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/invocationbuilder/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,8 +61,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = -8097693127928445210L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_client_invocationbuilder_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/syncinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/client/syncinvoker/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,8 +62,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   protected long millis;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_client_syncinvoker_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/constrainedto/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/constrainedto/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,8 +60,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 3343257931794865470L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_constrainedto_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,9 +56,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 111355567568365703L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_container_requestcontext_web/resource");
     setPrintEntity(true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/illegalstate/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/illegalstate/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,9 +49,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = -8112756483664393579L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_container_requestcontext_illegalstate_web/resource");
     setPrintEntity(true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/security/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/security/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,9 +56,23 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   protected String password;
 
   public JAXRSClientIT() {
-    usersetup();
     setContextRoot("/jaxrs_ee_rs_container_requestcontext_security_web/resource");
   }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
+    usersetup();
+  }
+
+  public void usersetup() {
+    user = System.getProperty("user");
+    password = System.getProperty("password");
+    assertTrue(!isNullOrEmpty(user), "user not set");
+    assertTrue(!isNullOrEmpty(password),
+        "password not set");
+  }
+
 
   @BeforeEach
   void logStartTest(TestInfo testInfo) {
@@ -89,15 +103,6 @@ public class JAXRSClientIT extends JaxrsCommonClient {
 
     archive.setWebXML(new StringAsset(webXml));
     return archive;
-  }
-
-  public void usersetup() {
-    user = System.getProperty("user");
-    password = System.getProperty("password");
-    assertTrue(!isNullOrEmpty(user), "user not set");
-    assertTrue(!isNullOrEmpty(password),
-        "password not set");
-    super.setup();
   }
 
   /*

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/resourceinfo/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/resourceinfo/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,9 +47,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = -2900337741491627385L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_container_resourceinfo_web/resource");
     setPrintEntity(true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,9 +66,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 7090474648496503290L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_container_responsecontext_web/resource");
     setPrintEntity(true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/cookieparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/cookieparam/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,7 +43,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
@@ -60,8 +59,12 @@ public class JAXRSClientIT extends JaxrsParamClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_cookieparam_web/CookieParamTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach
@@ -74,7 +77,7 @@ public class JAXRSClientIT extends JaxrsParamClient {
     TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
   }
 
-  @Deployment(testable = false, name = "cookieparam")
+  @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{
 
     InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/rs/cookieparam/web.xml.template");
@@ -403,7 +406,7 @@ public class JAXRSClientIT extends JaxrsParamClient {
           found = true;
     }
     assertTrue(found, "Could not find cookie"+ cookie+ "in response headers:"+
-        JaxrsUtil.iterableToString(";", headers));
+        JaxrsUtil.iterableToString(";", (Object) headers));
     logMsg("Found cookie", cookie, "as expected");
   }
 

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/cookieparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/cookieparam/locator/JAXRSLocatorClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.cookieparam.locator;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -34,11 +35,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.cookieparam.JAXRSClientIT;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -59,21 +63,33 @@ public class JAXRSLocatorClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSLocatorClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_cookieparam_locator_web/resource/locator");
   }
 
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_cookieparam_locator_web")
+  private URL url;
+
   @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSLocatorClientIT");
+
+    assertFalse((url==null), "[JAXRSLocatorClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSLocatorClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSLocatorClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSLocatorClientIT] Test setup OK");
+
   }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
 
-  @Deployment(testable = false, name = "cookieparamlocator")
+  @Deployment(testable = false, name="jaxrs_ee_rs_cookieparam_locator_web")
   public static WebArchive createDeployment() throws IOException{
 
     InputStream inStream = JAXRSLocatorClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/rs/cookieparam/locator/web.xml.template");

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/cookieparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/cookieparam/sub/JAXRSSubClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.cookieparam.sub;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -33,11 +34,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.cookieparam.CookieParamTest;
 import ee.jakarta.tck.ws.rs.ee.rs.cookieparam.JAXRSClientIT;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -58,21 +62,32 @@ public class JAXRSSubClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSSubClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_cookieparam_sub_web/Resource/subresource");
   }
 
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_cookieparam_sub_web")
+  private URL url;
+
   @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
-
-  @Deployment(testable = false, name = "cookieparamsub")
+  @Deployment(testable = false, name = "jaxrs_ee_rs_cookieparam_sub_web")
   public static WebArchive createDeployment() throws IOException{
 
     InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/rs/cookieparam/sub/web.xml.template");

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/application/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/application/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,8 +50,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
   
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_application_web/ApplicationTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private static final long serialVersionUID = 1L;

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/configurable/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/configurable/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,11 +73,14 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private int registeredInstancesCnt = -1;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_configurable_web/resource");
   }
 
-  
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
+
   @BeforeEach
   void logStartTest(TestInfo testInfo) {
     TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/configuration/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/configuration/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -80,10 +80,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 7215781408688132392L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_configuration_web/resource/echo");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
   
   @BeforeEach
   void logStartTest(TestInfo testInfo) {

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/headers/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/headers/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,10 +56,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = -5727774504018187299L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_headers_web/HeadersTest");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
   
   @BeforeEach
   void logStartTest(TestInfo testInfo) {

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/request/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/request/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,10 +52,13 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final String IF_NONE_MATCH = "If-None-Match: \"AAA\"";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_request_web/RequestTest");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
 
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/response/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/response/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,11 +85,14 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 4182256439207983256L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_response_web/resource");
     setPrintEntity(true);
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
   
   @BeforeEach
   void logStartTest(TestInfo testInfo) {

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/responsebuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/responsebuilder/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,8 +54,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_responsebuilder_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/securitycontext/basic/JAXRSBasicClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/securitycontext/basic/JAXRSBasicClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,8 +56,12 @@ public class JAXRSBasicClientIT
   private static final long serialVersionUID = 340277879725875946L;
 
   public JAXRSBasicClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_core_securitycontext_basic_web/Servlet");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT.java
@@ -50,10 +50,13 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   protected static final String RESOURCE = "resource";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/" + ROOT + "/" + RESOURCE);
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
   
   @BeforeEach
   void logStartTest(TestInfo testInfo) {

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/delete/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/delete/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,8 +46,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 204493956987397506L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_delete_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/clientwriter/interceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/clientwriter/interceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,10 +59,14 @@ public class JAXRSClientIT extends WriterClient<ContextOperation> {
   private static final long serialVersionUID = -5479399808367387477L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_ee_rs_ext_interceptor_clientwriter_interceptorcontext_web/resource");
     addProviders();
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/clientwriter/writerinterceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/clientwriter/writerinterceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,10 +54,14 @@ public class JAXRSClientIT extends WriterClient<ContextOperation> {
   private static final long serialVersionUID = 2500912584762173255L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_ee_rs_ext_interceptor_clientwriter_writerinterceptorcontext_web/resource");
     addProviders();
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerreader/interceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerreader/interceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,9 +65,13 @@ public class JAXRSClientIT extends ReaderClient<ContextOperation> {
   private static final long serialVersionUID = 6573164759617152350L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_ee_rs_ext_interceptor_containerreader_interceptorcontext_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerreader/readerinterceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerreader/readerinterceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,9 +61,13 @@ public class JAXRSClientIT extends ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.co
   private static final long serialVersionUID = 3006391868445878375L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_ee_rs_ext_interceptor_containerreader_readerinterceptorcontext_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerwriter/interceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerwriter/interceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,9 +55,13 @@ public class JAXRSClientIT extends WriterClient<ContextOperation> {
   private static final long serialVersionUID = -3980167967224950515L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_ee_rs_ext_interceptor_containerwriter_interceptorcontext_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerwriter/writerinterceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/interceptor/containerwriter/writerinterceptorcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,9 +53,13 @@ public class JAXRSClientIT extends WriterClient<ContextOperation> {
   private static final long serialVersionUID = -8158424518609416304L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_ee_rs_ext_interceptor_containerwriter_writerinterceptorcontext_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/paramconverter/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/paramconverter/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,8 +51,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 863071027768369551L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_ext_paramconverter_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/providers/JAXRSProvidersClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/ext/providers/JAXRSProvidersClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -68,11 +68,15 @@ public class JAXRSProvidersClientIT
   protected int expectedClasses = 1;
 
   public JAXRSProvidersClientIT() {
-    setup();
     TSAppConfig cfg = new TSAppConfig();
     setContextRoot("/jaxrs_ee_ext_providers_web/ProvidersServlet");
     expectedClasses = cfg.getClasses().size();
     expectedSingletons = cfg.getSingletons().size();
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/formparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/formparam/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,8 +58,12 @@ public class JAXRSClientIT extends JaxrsParamClient {
   private static final String DECODED = "_`'$X Y@\"a a\"";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_formparam_web/FormParamTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private static final long serialVersionUID = 1L;

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/formparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/formparam/locator/JAXRSLocatorClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,15 +29,19 @@ import ee.jakarta.tck.ws.rs.ee.rs.formparam.FormParamTest;
 import ee.jakarta.tck.ws.rs.ee.rs.formparam.JAXRSClientIT;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -56,21 +60,33 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSLocatorClientIT extends JAXRSClientIT {
 
   public JAXRSLocatorClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_formparam_locator_web/resource/locator");
+  }
+
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_formparam_locator_deployment")
+  private URL url;
+
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSLocatorClientIT");
+
+    assertFalse((url==null), "[JAXRSLocatorClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSLocatorClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSLocatorClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSLocatorClientIT] Test setup OK");
+
   }
 
   private static final long serialVersionUID = 1L;
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
-
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
 
   @Deployment(testable = false, name = "jaxrs_ee_formparam_locator_deployment")
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/formparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/formparam/sub/JAXRSSubClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,15 +27,19 @@ import ee.jakarta.tck.ws.rs.ee.rs.WebApplicationExceptionMapper;
 import ee.jakarta.tck.ws.rs.ee.rs.formparam.FormParamTest;
 import ee.jakarta.tck.ws.rs.ee.rs.formparam.JAXRSClientIT;
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -52,21 +56,32 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSSubClientIT extends JAXRSClientIT {
 
   public JAXRSSubClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_formparam_sub_web/resource/sub");
   }
 
-  private static final long serialVersionUID = 1L;
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_formparam_sub_deployment")
+  private URL url;
 
   @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
+  private static final long serialVersionUID = 1L;
 
   @Deployment(testable = false, name = "jaxrs_ee_formparam_sub_deployment")
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/get/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/get/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,8 +48,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_get_web/GetTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/head/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/head/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,8 +47,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_head_web/HeadTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/headerparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/headerparam/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,8 +58,12 @@ public class JAXRSClientIT extends JaxrsParamClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_headerparam_web/HeaderParamTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/headerparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/headerparam/locator/JAXRSLocatorClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.headerparam.locator;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -34,11 +35,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.headerparam.JAXRSClientIT;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -57,18 +61,29 @@ public class JAXRSLocatorClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSLocatorClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_headerparam_locator_web/resource/locator");
   }
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_headerparam_locator_deployment")
+  private URL url;
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
   @Deployment(testable = false, name = "jaxrs_ee_rs_headerparam_locator_deployment")

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/headerparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/headerparam/sub/JAXRSSubClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.headerparam.sub;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -37,11 +38,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.headerparam.JAXRSClientIT;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -62,19 +66,32 @@ public class JAXRSSubClientIT
   private static final long serialVersionUID = -7534318281215084279L;
 
   public JAXRSSubClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_headerparam_sub_web/resource/subresource");
   }
 
+
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_headerparam_sub_deployment")
+  private URL url;
+
   @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
 
   @Deployment(testable = false, name = "jaxrs_ee_rs_headerparam_sub_deployment")
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/matrixparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/matrixparam/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,8 +61,12 @@ public class JAXRSClientIT extends JaxrsParamClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_matrixparam_web/MatrixParamTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach
@@ -75,7 +79,7 @@ public class JAXRSClientIT extends JaxrsParamClient {
     TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
   }
 
-  @Deployment(testable = false, name = "jaxrs_ee_rs_matrixparam_deployment")
+  @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{
 
     InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/rs/matrixparam/web.xml.template");

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/matrixparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/matrixparam/locator/JAXRSLocatorClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.matrixparam.locator;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -34,11 +35,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.matrixparam.MatrixParamTest;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -59,18 +63,30 @@ public class JAXRSLocatorClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSLocatorClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_matrixparam_locator_web/resource/locator");
   }
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_matrixparam_locator_deployment")
+  private URL url;
+
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSLocatorClientIT");
+
+    assertFalse((url==null), "[JAXRSLocatorClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSLocatorClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSLocatorClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSLocatorClientIT] Test setup OK");
+
   }
 
   @Deployment(testable = false, name = "jaxrs_ee_rs_matrixparam_locator_deployment")

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/matrixparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/matrixparam/sub/JAXRSSubClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.matrixparam.sub;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -34,11 +35,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.matrixparam.MatrixParamTest;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -59,21 +63,34 @@ public class JAXRSSubClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSSubClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_matrixparam_sub_web/resource/subresource");
   }
 
+
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_matrixparam_sub_web")
+  private URL url;
+
   @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
 
-  @Deployment(testable = false)
+  @Deployment(testable = false, name="jaxrs_ee_rs_matrixparam_sub_web")
   public static WebArchive createDeployment() throws IOException{
 
     InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/rs/matrixparam/sub/web.xml.template");

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/options/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/options/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,8 +48,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_options_web/Options");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/pathparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/pathparam/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,9 +59,13 @@ public class JAXRSClientIT extends JaxrsParamClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_pathparam_web/PathParamTest");
     useDefaultValue = false;
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/pathparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/pathparam/locator/JAXRSLocatorClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.pathparam.locator;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.ParamEntityPrototype;
@@ -33,11 +34,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.pathparam.PathParamTest;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -58,22 +62,34 @@ public class JAXRSLocatorClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSLocatorClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_pathparam_locator_web/resource/locator");
   }
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_pathparam_locator_deployment")
+  private URL url;
+
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSLocatorClientIT");
+
+    assertFalse((url==null), "[JAXRSLocatorClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSLocatorClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSLocatorClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSLocatorClientIT] Test setup OK");
+
   }
 
   @Deployment(testable = false, name = "jaxrs_ee_rs_pathparam_locator_deployment")
-  public static WebArchive createDeployment() throws IOException{
+  public static WebArchive createDeployment() throws IOException {
 
     InputStream inStream = JAXRSLocatorClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/ee/rs/pathparam/locator/web.xml.template");
     String webXml = editWebXmlString(inStream);

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/pathparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/pathparam/sub/JAXRSSubClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.pathparam.sub;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.ParamEntityPrototype;
@@ -33,11 +34,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.pathparam.PathParamTest;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -58,18 +62,30 @@ public class JAXRSSubClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSSubClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_pathparam_sub_web/resource/subresource");
   }
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_pathparam_sub_deployment")
+  private URL url;
+
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
   @Deployment(testable = false, name = "jaxrs_ee_rs_pathparam_sub_deployment")

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/produceconsume/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/produceconsume/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,8 +50,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 3927081991341346347L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_produceconsume_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/put/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/put/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,8 +42,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = -71817508809693264L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_put_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/queryparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/queryparam/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,8 +61,12 @@ public class JAXRSClientIT extends JaxrsParamClient {
   private static final long serialVersionUID = 1L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_queryparam_web/QueryParamTest");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/queryparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/queryparam/sub/JAXRSSubClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@
 package ee.jakarta.tck.ws.rs.ee.rs.queryparam.sub;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.ee.rs.JaxrsParamClient;
@@ -37,11 +38,14 @@ import ee.jakarta.tck.ws.rs.ee.rs.queryparam.QueryParamTest;
 import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -61,20 +65,32 @@ public class JAXRSSubClientIT
   private static final long serialVersionUID = 1L;
 
   public JAXRSSubClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_rs_queryparam_sub_web/resource/subresource");
   }
 
+  
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs_ee_rs_queryparam_sub_deployment")
+  private URL url;
+
   @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
+  public void setup() {
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
-  }
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
 
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
+  }
+  
   @Deployment(testable = false, name = "jaxrs_ee_rs_queryparam_sub_deployment")
   public static WebArchive createDeployment() throws IOException{
 

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/api/client/invocationbuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/api/client/invocationbuilder/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,8 +50,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs21_api_client_invocationbuilder_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/client/executor/async/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/client/executor/async/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.async;
 
 import java.io.IOException;
+import java.net.URL;
 
 import ee.jakarta.tck.ws.rs.common.impl.TRACE;
 import ee.jakarta.tck.ws.rs.ee.rs.client.asyncinvoker.Resource;
@@ -30,10 +31,13 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.WebTarget;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -55,18 +59,30 @@ public class JAXRSClientIT
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_ee_client_executor_async_web/resource");
   }
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
+  
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs21_ee_client_executor_async_deployment")
+  private URL url;
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSSubClientIT");
+
+    assertFalse((url==null), "[JAXRSSubClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSSubClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSSubClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSSubClientIT] Test setup OK");
+
   }
 
   @Deployment(testable = false, name = "jaxrs21_ee_client_executor_async_deployment")

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.rx;
 
 import java.io.IOException;
+import java.net.URL;
 
 import ee.jakarta.tck.ws.rs.common.impl.TRACE;
 import ee.jakarta.tck.ws.rs.jaxrs21.ee.client.rxinvoker.Resource;
@@ -30,10 +31,13 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -58,18 +62,30 @@ public class JAXRSClientIT
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_ee_client_executor_rx_web/resource");
   }
 
-  @BeforeEach
-  void logStartTest(TestInfo testInfo) {
-    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
-  }
+  
+  @ArquillianResource
+  @OperateOnDeployment("jaxrs21_ee_client_executor_rx_deployment")
+  private URL url;
 
-  @AfterEach
-  void logFinishTest(TestInfo testInfo) {
-    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  @BeforeEach
+  public void setup() {
+
+    TestUtil.logTrace("setup method JAXRSClientIT");
+
+    assertFalse((url==null), "[JAXRSClientIT] 'url' was not injected.");
+    
+    String hostname = url.getHost();
+    String portnum = Integer.toString(url.getPort());
+    
+    assertFalse(isNullOrEmpty(hostname), "[JAXRSClientIT] 'webServerHost' was not set.");
+    _hostname = hostname.trim();
+    assertFalse(isNullOrEmpty(portnum), "[JAXRSClientIT] 'webServerPort' was not set.");
+    _port = Integer.parseInt(portnum.trim());
+    TestUtil.logMsg("[JAXRSClientIT] Test setup OK");
+
   }
 
   @Deployment(testable = false, name = "jaxrs21_ee_client_executor_rx_deployment")

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,8 +76,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private final static String NONEXISTING_SITE = "somenonexisting.domain-site";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_ee_client_rxinvoker_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/patch/server/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/patch/server/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,8 +53,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_ee_patch_server_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/priority/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/priority/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,8 +45,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_ee_priority_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java
@@ -70,10 +70,9 @@ public class JAXRSClientIT extends SSEJAXRSClient {
 
   public JAXRSClientIT() {
     setContextRoot("/jaxrs_jaxrs21_ee_sse_ssebroadcaster_web");
-    setup();
   }
 
-  @Override
+  @BeforeEach
   public void setup() {
     super.setup();
     target = ClientBuilder.newClient()

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -74,8 +74,12 @@ public class JAXRSClientIT extends SSEJAXRSClient {
   protected int sleep = -1;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_ee_sse_sseeventsink_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,9 +85,13 @@ public class JAXRSClientIT extends SSEJAXRSClient {
   private int mediaTestLevel = 0;
 
   public JAXRSClientIT() {
-    setup();
     mediaTestLevel = 0;
     setContextRoot("/jaxrs_jaxrs21_ee_sse_sseeventsource_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/spec/classsubresourcelocator/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/spec/classsubresourcelocator/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,8 +49,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_spec_classsubresourcelocator_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/spec/completionstage/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs21/spec/completionstage/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,8 +51,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 21L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs21_spec_completionstage_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/jaxrs31/spec/extensions/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,8 +47,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 31L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_jaxrs31_spec_jdkservices_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @BeforeEach

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/servlet3/rs/applicationpath/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/servlet3/rs/applicationpath/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,8 +45,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   private static final long serialVersionUID = 1L;
     
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_ee_applicationpath");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/servlet3/rs/core/streamingoutput/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/servlet3/rs/core/streamingoutput/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,8 +46,12 @@ public class JAXRSClientIT extends JAXRSCommonClient {
   public static final String _root = "/jaxrs_ee_core_streamoutput/StreamOutputTest";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(_root);
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/servlet3/rs/ext/paramconverter/autodiscovery/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/servlet3/rs/ext/paramconverter/autodiscovery/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,9 +51,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = 8764917394183731977L;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_servlet3_rs_ext_paramconverter_autodiscovery/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/instance/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/instance/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,7 +61,6 @@ public class JAXRSClientIT extends JAXRSCommonClient {
 
 
   public JAXRSClientIT() {
-    setup();
     Client client = ClientBuilder.newClient();
     Configuration config = client.getConfiguration();
     registeredPropertyCnt = config.getProperties().size();
@@ -70,7 +69,6 @@ public class JAXRSClientIT extends JAXRSCommonClient {
     logMsg("Already registered", registeredPropertyCnt, "properties");
 
   }
-
 
   /* Run test */
   /*

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/invocations/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/invocations/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,8 +51,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_client_invocations_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/resource/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/resource/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,8 +41,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_client_resource_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/typedentities/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/typedentities/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,8 +66,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final String entity = Resource.class.getName();
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_client_typedentities_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/typedentitieswithxmlbinding/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/typedentitieswithxmlbinding/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,10 +50,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final String entity = Resource.class.getName();
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_client_typedentitieswithxmlbinding_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/webtarget/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/client/webtarget/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,10 +44,8 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_client_webtarget_web/resource");
   }
-
  
   @BeforeEach
   void logStartTest(TestInfo testInfo) {

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/context/client/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/context/client/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_context_client_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/context/server/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/context/server/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,8 +43,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_context_server_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/dynamicfeature/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/dynamicfeature/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_filter_dynamicfeature_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/exception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/exception/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,10 +46,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_filter_exception_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/globalbinding/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/globalbinding/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_filter_globalbinding_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/interceptor/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/interceptor/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,10 +82,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   }
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_filter_interceptor_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/lastvalue/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/lastvalue/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,10 +52,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   public static final String plaincontent = JAXRSClientIT.class.getName();
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_filter_lastvalue_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/namebinding/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/filter/namebinding/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_filter_namebinding_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/inheritance/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/inheritance/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,11 +40,14 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_inheritance_web");
   }
 
- 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
+
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{
     InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("ee/jakarta/tck/ws/rs/spec/inheritance/web.xml.template");

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/exceptionmapper/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/exceptionmapper/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_exceptionmapper_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/jaxbcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/jaxbcontext/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,8 +46,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_jaxbcontext_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private void setPropertyAndInvoke(String resourceMethod) throws Fault {

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/overridestandard/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/overridestandard/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,8 +48,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_overridestandard_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private void setPropertyAndInvoke(String resourceMethod, MediaType md)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/reader/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/reader/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,10 +46,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_reader_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
 
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/sort/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/sort/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,10 +47,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_sort_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standard/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standard/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,8 +51,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_standard_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private void setPropertyAndInvoke(String resourceMethod, MediaType md)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardhaspriority/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardhaspriority/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,8 +49,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_standardhaspriority_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private void setPropertyAndInvoke(String resourceMethod, MediaType md)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardnotnull/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardnotnull/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,10 +62,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_standardnotnull_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardwithjaxrsclient/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardwithjaxrsclient/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,8 +47,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_standardwithjaxrsclient_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private void setPropertyAndInvoke(String resourceMethod, MediaType md)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardwithxmlbinding/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/standardwithxmlbinding/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,8 +45,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_standardwithxmlbinding_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
   private void setPropertyAndInvoke(String resourceMethod, MediaType md)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/visibility/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/visibility/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,8 +44,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_visibility_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/writer/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/provider/writer/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,8 +45,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_provider_writer_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/annotationprecedence/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/annotationprecedence/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,10 +44,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_resource_annotationprecedence_web/resource");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/annotationprecedence/subclass/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/annotationprecedence/subclass/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,9 +46,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot(
         "/jaxrs_spec_resource_annotationprecedence_subclass_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/locator/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/locator/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,8 +41,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_resource_locator_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_resource_requestmatching_web");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/responsemediatype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/responsemediatype/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_resource_responsemediatype_web");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/valueofandfromstring/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/valueofandfromstring/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,10 +45,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final String DATA = "ASDFGHJKLQWERTYUIOPPPPPPP";
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_resource_valueofandfromstring_web");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
  
   @Deployment(testable = false)
   public static WebArchive createDeployment() throws IOException{

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resourceconstructor/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resourceconstructor/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,8 +45,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_resourceconstructor_web/resource");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
  

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/returntype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/returntype/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,10 +51,13 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   private static final long serialVersionUID = ReturnTypeTest.serialVersionUID;
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_returntype_web/ReturnTypeTest");
   }
 
+  @BeforeEach
+  public void setup() {
+    super.setup();
+  }
   
  
   @Deployment(testable = false)

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/template/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/template/JAXRSClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,8 +38,12 @@ import org.junit.jupiter.api.AfterEach;
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   public JAXRSClientIT() {
-    setup();
     setContextRoot("/jaxrs_spec_templateTest_web");
+  }
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
   }
 
 

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,16 +35,24 @@
     <description>This test verifies the compliance of Eclipse Jersey with Jakarta REST</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <jersey.version>3.1.0-M3</jersey.version>
-        <glassfish.container.version>6.2.5</glassfish.container.version>
-        <glassfish.home>${project.build.directory}/glassfish6</glassfish.home>
-        <jakarta.platform.version>10.0.0-RC1</jakarta.platform.version>
-        <junit.jupiter.version>5.7.2</junit.jupiter.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <jersey.version>4.0-M1-GF1</jersey.version>
+        <glassfish.container.version>8.0.0-M1</glassfish.container.version>
+        <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
+        <jakarta.platform.version>11.0.0-M1</jakarta.platform.version>
+        <junit.jupiter.version>5.9.3</junit.jupiter.version>
         <jakarta.rest.version>4.0.0-SNAPSHOT</jakarta.rest.version>
         <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>jakarta-snapshots</id>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+        </repository>
+    </repositories>
+
 
     <dependencyManagement>
         <dependencies>
@@ -55,13 +63,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
+            <!-- <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
-                <version>${jersey.version}</version>
+                <version>4.0-M1-GF</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
+            </dependency> -->
         </dependencies>
     </dependencyManagement>
 
@@ -101,7 +109,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -149,10 +157,17 @@
             <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency> 
+
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>4.0-M1-GF1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.4</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
@@ -160,6 +175,7 @@
             <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-jaxb</artifactId>
@@ -201,7 +217,8 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <execution>
+
+                    <!-- <execution>
                         <id>copy</id>
                         <phase>pre-integration-test</phase>
                         <goals>
@@ -292,9 +309,29 @@
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
+                    </execution> -->
+                </executions>
+            </plugin>
+                        <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target>
+                                <!-- <echo message="unzipping file"></echo> -->
+                                <!-- <unzip dest="target/" src="target/glassfish.zip"></unzip> -->
+                                <chmod dir="target/glassfish7/glassfish/bin/asadmin" perm="777"></chmod>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>exec-maven-plugin</artifactId>
                 <groupId>org.codehaus.mojo</groupId>
@@ -306,7 +343,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>stop-domain</argument>
                             </arguments>
@@ -319,7 +356,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>start-domain</argument>
                             </arguments>
@@ -332,7 +369,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>set</argument>
                                 <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
@@ -346,7 +383,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>--passwordfile</argument>
                                 <argument>${project.basedir}/j2ee.pass</argument>
@@ -366,7 +403,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>--passwordfile</argument>
                                 <argument>${project.basedir}/j2ee.pass</argument>
@@ -384,7 +421,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>--passwordfile</argument>
                                 <argument>${project.basedir}/javajoe.pass</argument>
@@ -404,7 +441,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>--passwordfile</argument>
                                 <argument>${project.basedir}/javajoe.pass</argument>
@@ -422,7 +459,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>list-file-users</argument>
                             </arguments>
@@ -435,7 +472,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/glassfish6/glassfish/bin/asadmin</executable>
+                            <executable>${glassfish.home}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>stop-domain</argument>
                             </arguments>
@@ -462,8 +499,6 @@
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${glassfish.home}</GLASSFISH_HOME>
                                 <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>
-                                <webServerHost>localhost</webServerHost>
-                                <webServerPort>8080</webServerPort>
                                 <junit.log.traceflag>true</junit.log.traceflag>
                                 <user>j2ee</user>
                                 <password>j2ee</password>


### PR DESCRIPTION
- Avoids hardcoding the webServerHost and webServerPort as system properties.
- Tested with Glassfish/Jersey only now.

