### PR TITLE
fast-track: Add 4.0 content to Specification appendix

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.1-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.1-release.adoc
@@ -16,7 +16,7 @@ annotation support.  Managed bean support is now part of CDI.
 * <<java-se>>: Clarified when the two alternative ways of publishing on 
 Java SE must be supported.
 * Removed `Link.JaxbLink` and `Link.JaxbAdapter` inner classes.
-* Added `getHeaderString()` method to `ClientRequestContext`, `ClientResponseContext`,
+* Added `containsHeaderString()` method to `ClientRequestContext`, `ClientResponseContext`,
 `ContainerRequestContext`, `ContainerResponseContext`, and `HttpHeaders`.
-* Added `APPLICATION_MERGE_PATCH_JSON` to `MediaType`
+* Added `APPLICATION_MERGE_PATCH_JSON` and `APPLICATION_MERGE_PATCH_JSON_TYPE` to `MediaType`
 * Added `getMatchedResourceTemplates()` method to `UriInfo`.

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.1-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.1-release.adoc
@@ -15,3 +15,8 @@
 annotation support.  Managed bean support is now part of CDI.
 * <<java-se>>: Clarified when the two alternative ways of publishing on 
 Java SE must be supported.
+* Removed `Link.JaxbLink` and `Link.JaxbAdapter` inner classes.
+* Added `getHeaderString()` method to `ClientRequestContext`, `ClientResponseContext`,
+`ContainerRequestContext`, `ContainerResponseContext`, and `HttpHeaders`.
+* Added `APPLICATION_MERGE_PATCH_JSON` to `MediaType`
+* Added `getMatchedResourceTemplates()` method to `UriInfo`.

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/RequestFilter.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/RequestFilter.java
@@ -180,7 +180,7 @@ public class RequestFilter extends TemplateFilter {
     }
     abortWithEntity(sb.toString());
   }
- 
+
   public void getHeadersIsMutable() {
     String key = "KEY";
     MultivaluedMap<String, String> headers = requestContext.getHeaders();


### PR DESCRIPTION
Added 4.0 content to the Changes since 3.1 appendix section of the spec.

Added removal of space accidentally added before an EOL in merged PR #1238