### PR TITLE
fast-track: TCK documentation and dependency update for 4.0

### DIFF
--- a/jaxrs-tck/docs/JAXRSTCK4.0-ReleaseNotes.html
+++ b/jaxrs-tck/docs/JAXRSTCK4.0-ReleaseNotes.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=windows-1252">
     <title>Jakarta RESTful Web Services TCK Release Notes</title>
     <!--
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.    This program and the accompanying materials are made available under the    terms of the Eclipse Public License v. 2.0, which is available at    http://www.eclipse.org/legal/epl-2.0.    This Source Code may also be made available under the following Secondary
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.    This program and the accompanying materials are made available under the    terms of the Eclipse Public License v. 2.0, which is available at    http://www.eclipse.org/legal/epl-2.0.    This Source Code may also be made available under the following Secondary
     Licenses when the conditions for such availability set forth in the    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,    version 2 with the GNU Classpath Exception, which is available at    https://www.gnu.org/software/classpath/license.html.    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0-->
     <style type="text/css">
 <!--
@@ -28,25 +28,14 @@ td {  padding-left: 3pt;}
   <body>
     <div align="center">
       <h1>Jakarta EE RESTful Web Services Technology Compatibility
-        Kit, Version 3.1<br>
-        <span class="emphasize">Release Notes, March 2022</span></h1>
+        Kit, Version 4.0<br>
+        <span class="emphasize">Release Notes, March 2024</span></h1>
     </div>
-    <hr size="3">
-    <h2>Release Notes Update For Eclipse Jersey 3.1.0 Compatible Implementation
-      Release March 2022 </h2>
-    <p> A couple of changes made in Eclipse Jersey 3.1.0 Compatible
-      Implementation (CI) prompts this note. </p>
-    <ul>
-      <li>
-        <p>The Eclipse Jersey 3.1.0 release requires the use of Java SE 11
-          and this is also required when running the Jakarta EE RESTful Web
-          Services TCK against Jersey 3.1. </p>
-      </li>
     </ul>
     <p></p>
     <hr>
     <h2>Kit Contents </h2>
-    <p>The Jakarta EE RESTful Web Services 3.1 Technology Compatibility Kit
+    <p>The Jakarta EE RESTful Web Services 4.0 Technology Compatibility Kit
       (TCK) includes the following items:</p>
     <ul>
       <li>
@@ -56,66 +45,66 @@ td {  padding-left: 3pt;}
           <li>
             <p>A <strong>signature test</strong> that checks that all of the
               public APIs are supported or defined in the Jakarta EE RESTful Web
-              Services 3.1 implementation that is under test.</p>
+              Services 4.0 implementation that is under test.</p>
           </li>
           <li>
             <p><strong>Specification tests</strong> for the testable assertions
-              required by the Jakarta EE RESTful Web Services 3.1 Specification.</p>
+              required by the Jakarta EE RESTful Web Services 4.0 Specification.</p>
           </li>
           <li>
             <p><strong>API tests</strong> for the public APIs and language
-              elements defined by the Jakarta EE RESTful Web Services 3.1
+              elements defined by the Jakarta EE RESTful Web Services 4.0
               Specification.</p>
           </li>
         </ul>
       </li>
     </ul>
     <hr>
-    <h2>Jakarta EE RESTful Web Services 3.1 TCK Facts</h2>
+    <h2>Jakarta EE RESTful Web Services 4.0 TCK Facts</h2>
     <p>The test suite bundle contains the following:</p>
     <ul>
-      <li>2796 total tests</li>
+      <li>2722 total tests out of which 128 tests are excluded</li>
     </ul>
     <hr>
     <h2>Platform Notes</h2>
-    <p>The Jakarta EE RESTful Web Services 3.1 TCK tests and the Jakarta EE
-      RESTful Web Services 3.1 Compatible Implementation (CI) can be run with
-      Java Platform, Standard Edition version 11.0 (Java SE 11). 
+    <p>The Jakarta EE RESTful Web Services 4.0 TCK tests and the Jakarta EE
+      RESTful Web Services 4.0 Compatible Implementation (CI) can be run with
+      Java Platform, Standard Edition version 17.0 (Java SE 17). 
       See <a href="#ReferenceRuntime">Compatible
-        Runtime for Jakarta EE RESTful Web Services 3.1</a> for additional
+        Runtime for Jakarta EE RESTful Web Services 4.0</a> for additional
       information.</p>
     <p>Refer to the <cite>Technology Compatibility Kit User's Guide for Jakarta
-        EE RESTful Web Services</cite> (<a href="html-usersguide/title.html" title="Jakarta EE RESTful Web Services 3.1 TCK User's Guide (HTML)">HTML</a>,
+        EE RESTful Web Services</cite> (<a href="html-usersguide/title.html" title="Jakarta EE RESTful Web Services 4.0 TCK User's Guide (HTML)">HTML</a>,
       <a href="./pdf-usersguide/Jakarta-RESTful-Web-Services-TCK-Users-Guide.pdf"
 
-        title="Jakarta EE RESTful Web Services 3.1 TCK User's Guide (PDF)">PDF</a>)
+        title="Jakarta EE RESTful Web Services 4.0 TCK User's Guide (PDF)">PDF</a>)
       for platform compatibility requirements and notes.</p>
     <hr> <a name="ReferenceRuntime"></a>
-    <h2>Compatible Runtime for Jakarta EE RESTful Web Services 3.1</h2>
+    <h2>Compatible Runtime for Jakarta EE RESTful Web Services 4.0</h2>
     <p>A Compatible Runtime for compatibility testing of implementations based
-      upon the Jakarta EE RESTful Web Services 3.1 Specification is as follows:</p>
+      upon the Jakarta EE RESTful Web Services 4.0 Specification is as follows:</p>
     <ul>
       <li>
-        <p>Java SE 11 which must be used with a Jakarta EE
+        <p>Java SE 17 which must be used with a Jakarta EE
           profile/application server, such as the  
-          GlassFish 6.1+ (with Java SE 11+)</p>
+          GlassFish 8.0.0+ (with Java SE 17+)</p>
       </li>
       <li>A Compatible Implementation (CI) of Jakarta EE RESTful Web Services
-        3.1 is available as part of the Eclipse GlassFish 6.1+ full
-        profile, or the Eclipse GlassFish 6.1+, Web Profile</li>
+        4.0 is available as part of the Eclipse GlassFish 8.0.0+ full
+        profile, or the Eclipse GlassFish 8.0.0+, Web Profile</li>
     </ul>
-    <p>The Jakarta EE RESTful Web Services 3.1 TCK tests have been run on the
+    <p>The Jakarta EE RESTful Web Services 4.0 TCK tests have been run on the
       following platforms: </p>
     <ul>
       <li>CentOS Linux 7 </li>
     </ul>
     <hr> <a name="install_setup_run"></a>
     <h2>Installing, Setting Up, and Running the Jakarta EE RESTful Web Services
-      3.1 TCK</h2>
+      4.0 TCK</h2>
     <p>Refer to the <cite>Technology Compatibility Kit User's Guide for Jakarta
-        EE RESTful Web Services 3.1</cite> for complete instructions on
+        EE RESTful Web Services 4.0</cite> for complete instructions on
       installing, setting up, and running the Jakarta EE RESTful Web Services
-      3.1 TCK. </p>
+      4.0 TCK. </p>
     
     <hr>
    

--- a/jaxrs-tck/docs/JAXRSTCK4.0-ReleaseNotes.html
+++ b/jaxrs-tck/docs/JAXRSTCK4.0-ReleaseNotes.html
@@ -69,7 +69,7 @@ td {  padding-left: 3pt;}
     <h2>Platform Notes</h2>
     <p>The Jakarta EE RESTful Web Services 4.0 TCK tests and the Jakarta EE
       RESTful Web Services 4.0 Compatible Implementation (CI) can be run with
-      Java Platform, Standard Edition version 17.0 (Java SE 17). 
+      Java Platform, Standard Edition version 17.0 (Java SE 17) and 21.0 (Java SE 21).
       See <a href="#ReferenceRuntime">Compatible
         Runtime for Jakarta EE RESTful Web Services 4.0</a> for additional
       information.</p>

--- a/jaxrs-tck/docs/assertions/JAXRSSpecAssertions_3.1.0.xml
+++ b/jaxrs-tck/docs/assertions/JAXRSSpecAssertions_3.1.0.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE spec SYSTEM "https://raw.githubusercontent.com/eclipse-ee4j/jakartaee-tck/master/internal/docs/dtd/spec_assertions.dtd">
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/docs/assertions/JAXRSSpecAssertions_4.0.0.html
+++ b/jaxrs-tck/docs/assertions/JAXRSSpecAssertions_4.0.0.html
@@ -3,7 +3,7 @@
 <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@
 <body bgcolor="white">
 <br>
 <CENTER>
-<h2>  Jakarta RESTful Web Services - 3.1<br>
+<h2>  Jakarta RESTful Web Services - 4.0<br>
 				Specification Assertion Detail 
 			</h2>
 </CENTER>
@@ -1216,7 +1216,7 @@
 </TR>
 
 <TR>
-<TD align="center" valign="center"><a name="JAXRS:SPEC:131"></a><font size="1PT">JAXRS:SPEC:131</font></TD><TD align="center" valign="center"><font size="1PT">2</font></TD><TD align="center" valign="center"><font size="1PT">3.1</font></TD><TD align="left" valign="center"><font size="1PT">There are two alternative ways of publishing on Java SE: Creating SE endpoints directly or using the SE bootstrap API. A compliant implementation MUST support both alternatives on Java SE. </font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
+<TD align="center" valign="center"><a name="JAXRS:SPEC:131"></a><font size="1PT">JAXRS:SPEC:131</font></TD><TD align="center" valign="center"><font size="1PT">2</font></TD><TD align="center" valign="center"><font size="1PT">3.1</font></TD><TD align="left" valign="center"><font size="1PT">There are two alternative ways of publishing on Java SE: Creating SE endpoints directly or using the SE bootstrap API. Any compliant implementation that supports either of these alternatives on Java SE MUST support both. </font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
 </font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">technology</font></TD><TD align="center" valign="center"><font size="1PT">active</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD>
 </TR>

--- a/jaxrs-tck/docs/assertions/JAXRSSpecAssertions_4.0.0.xml
+++ b/jaxrs-tck/docs/assertions/JAXRSSpecAssertions_4.0.0.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE spec SYSTEM "https://raw.githubusercontent.com/eclipse-ee4j/jakartaee-tck/master/internal/docs/dtd/spec_assertions.dtd">
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
     <technology>RESTful Web Services</technology>
     <id>JAX-RS</id>
     <name>Java(TM) API for RESTful Web Services</name>
-    <version>3.1</version>
+    <version>4.0</version>
     <location-names>
         <chapters>
             <chapter id="2" name="Applications">
@@ -1399,7 +1399,7 @@
         <!-- JAXRS 3.1-->
         <assertion required="true" impl-spec="false" defined-by="technology" status="active" testable="true">
             <id>JAXRS:SPEC:131</id>
-            <description>There are two alternative ways of publishing on Java SE: Creating SE endpoints directly or using the SE bootstrap API. A compliant implementation MUST support both alternatives on Java SE.</description>
+            <description>There are two alternative ways of publishing on Java SE: Creating SE endpoints directly or using the SE bootstrap API. Any compliant implementation that supports either of these alternatives on Java SE MUST support both.</description>
             <location chapter="2" section="3.1"/>
         </assertion>
         <assertion required="true" impl-spec="false" defined-by="technology" status="active" testable="true">

--- a/jaxrs-tck/docs/index.html
+++ b/jaxrs-tck/docs/index.html
@@ -23,39 +23,39 @@ h4 {  font-style: italic; color: #000099}
   <body>
     <div align="Center">
       <h1>Welcome to the Jakarta EE RESTful Web Services Test
-        Compatibility Kit, Version 3.1</h1>
+        Compatibility Kit, Version 4.0</h1>
       <h2> <span class="emphasize">Your Starting Point</span></h2>
     </div>
     <hr>
-    <h2>Jakarta EE RESTful Web Services 3.1 TCK Documentation</h2>
-    <p>The Jakarta EE RESTful Web Services 3.1 TCK documentation includes the
+    <h2>Jakarta EE RESTful Web Services 4.0 TCK Documentation</h2>
+    <p>The Jakarta EE RESTful Web Services 4.0 TCK documentation includes the
       following:</p>
     <ul>
       <li>
-        <p>The <cite><a href="JAXRSTCK3.1-ReleaseNotes.html">Jakarta EE RESTful
-              Web Services 3.1 Release Notes</a></cite>, provide late-breaking
-          information about the Jakarta EE RESTful Web Services 3.1 TCK</p>
+        <p>The <cite><a href="JAXRSTCK4.0-ReleaseNotes.html">Jakarta EE RESTful
+              Web Services 4.0 Release Notes</a></cite>, provide late-breaking
+          information about the Jakarta EE RESTful Web Services 4.0 TCK</p>
       </li>
       <li>
-        <p>The <em><a href="html-usersguide/title.html" title="Jakarta EE RESTful Web Services 3.1 TCK User's Guide (HTML)">Jakarta
-              EE RESTful Web Services 3.1 Technology Compatibility Kit User's
+        <p>The <em><a href="html-usersguide/title.html" title="Jakarta EE RESTful Web Services 4.0 TCK User's Guide (HTML)">Jakarta
+              EE RESTful Web Services 4.0 Technology Compatibility Kit User's
               Guide</a></em> (or in <a href="./pdf-usersguide/Jakarta-RESTful-Web-Services-TCK-Users-Guide.pdf"
 
-            title="Jakarta EE RESTful Web Services 3.1 TCK User's Guide (PDF)">PDF</a>)
+            title="Jakarta EE RESTful Web Services 4.0 TCK User's Guide (PDF)">PDF</a>)
           provides the information that you need to install, set up, and run the
-          Jakarta EE RESTful Web Services 3.1 TCK. The guide also provides the
+          Jakarta EE RESTful Web Services 4.0 TCK. The guide also provides the
           rules with which you must comply to pass the Jakarta EE RESTful Web
-          Services 3.1 TCK.</p>
+          Services 4.0 TCK.</p>
       </li>
       <li>
-        <p>The <a href="assertions/JAXRSJavadocAssertions_3.1.0.html">Javadoc
+        <p>The <a href="assertions/JAXRSJavadocAssertions_4.0.0.html">Javadoc
             Assertion List</a> includes the javadoc assertions that are
-          indirectly tested by the Jakarta EE RESTful Web Services 3.1 TCK.</p>
+          indirectly tested by the Jakarta EE RESTful Web Services 4.0 TCK.</p>
       </li>
       <li>
-        <p>The <a href="assertions/JAXRSSpecAssertions_3.1.0.html">Specification
+        <p>The <a href="assertions/JAXRSSpecAssertions_4.0.0.html">Specification
             Assertion List</a> includes the specification assertions that are
-          tested by the Jakarta EE RESTful Web Services 3.1 TCK.</p>
+          tested by the Jakarta EE RESTful Web Services 4.0 TCK.</p>
       </li>
     </ul>
     

--- a/jaxrs-tck/docs/userguide/src/main/jbake/content/attributes.conf
+++ b/jaxrs-tck/docs/userguide/src/main/jbake/content/attributes.conf
@@ -1,14 +1,14 @@
 :TechnologyFullName: Jakarta RESTful Web Services
 :TechnologyShortName: Jakarta REST
 :LegacyAcronym: JAX-RS	   
-:TechnologyVersion: 3.1
-:TechnologyRI: Eclipse Jersey 3.1
-:ReleaseDate: March 2022
-:CopyrightDates: 2017, 2022
+:TechnologyVersion: 4.0
+:TechnologyRI: Eclipse Jersey 4.0
+:ReleaseDate: March 2024
+:CopyrightDates: 2017, 2024
 :TechnologyRIURL: https://projects.eclipse.org/projects/ee4j.jersey
-:SpecificationURL: https://jakarta.ee/specifications/restful-ws/3.1/
-:TCKInquiryList: mailto:jaxrs-dev@eclipse.org[jaxrs-dev@eclipse.org]
-:SpecificationInquiryList: mailto:jaxrs-dev@eclipse.org[jaxrs-dev@eclipse.org]
+:SpecificationURL: https://jakarta.ee/specifications/restful-ws/4.0/
+:TCKInquiryList: mailto:rest-dev@eclipse.org[rest-dev@eclipse.org]
+:SpecificationInquiryList: mailto:rest-dev@eclipse.org[rest-dev@eclipse.org]
 :techID: RESTfulWS
 // Define this attribute (uncomment it) if the TCK includes no API tests.  (Rare.)
 // :no-api-tests:
@@ -22,9 +22,9 @@
 // for the technology.  Used in config.inc.
 :TechnologyHomeEnv: JAXRS_HOME
 // Java SE version required.
-:SEversion: 11
+:SEversion: 17
 :MavenVersion: 3.6.3+
-:JakartaEEVersion: 10
+:JakartaEEVersion: 11
 :excludeListFileName: jaxrs-tck/docs/TCK-Exclude-List.txt
 :groupsExample: xml_binding
 :TCKPackageName: jakarta-restful-ws-tck-x.y.z.zip

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -35,12 +35,15 @@
     </parent>
 
     <properties>
-        <json.api.version>2.0.1</json.api.version>
-        <json.bind.api.version>2.0.0</json.bind.api.version>
+        <json.api.version>2.1.3</json.api.version>
+        <json.bind.api.version>3.0.0</json.bind.api.version>
         <xml.bind.api.version>4.0.0</xml.bind.api.version>
-        <servlet.api.version>6.0.0</servlet.api.version>
+        <servlet.api.version>6.1.0-M2</servlet.api.version>
         <common.httpclient.version>3.1</common.httpclient.version>
         <arquillian.version>1.8.0.Final</arquillian.version>
+        <junit.jupiter.version>5.9.3</junit.jupiter.version>
+        <annotation-api.version>3.0.0-M1</annotation-api.version>
+        <activation-api.version>2.1.3</activation-api.version>
     </properties>
 
     <dependencies>
@@ -65,6 +68,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
         </dependency>
 
         <dependency>
@@ -87,6 +91,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+            <version>${annotation-api.version}</version>
         </dependency>
 
         <dependency>
@@ -98,6 +103,7 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
+            <version>${activation-api.version}</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -41,7 +41,6 @@
         <servlet.api.version>6.1.0-M2</servlet.api.version>
         <common.httpclient.version>3.1</common.httpclient.version>
         <arquillian.version>1.8.0.Final</arquillian.version>
-        <junit.jupiter.version>5.9.3</junit.jupiter.version>
         <annotation-api.version>3.0.0-M1</annotation-api.version>
         <activation-api.version>2.1.3</activation-api.version>
     </properties>
@@ -68,7 +67,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
In jaxrs-tck/docs/

- New file JAXRSTCK4.0-ReleaseNotes.html  replacing JAXRSTCK3.1-ReleaseNotes.html with basic changes including version.

- Created new Spec Assertions file JAXRSSpecAssertions_4.0.0.html/xml that has the recent update made to JAXRS:SPEC:131 via https://github.com/jakartaee/rest/pull/1231. Retained JAXRSSpecAssertions_3.1.0.html/xml with contents from release 3.1. Any further update to the spec assertions for release 4.0 can go in JAXRSSpecAssertions_4.0.0.html/xml. 

- index.html and userguide config file jaxrs-tck/docs/userguide/src/main/jbake/content/attributes.conf updated with basic version updates.

- Update jaxrs-tck/pom,xml with latest versions of dependencies.

cc @jim-krueger @spericas @jansupol @jamezp 