### PR TITLE
Correct optionsOnSubResourceTest to allow "allow" in header text

### DIFF
--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.ws.rs.spec.resource.requestmatching;
 
 import java.io.InputStream;
+import java.util.Locale;
 import java.io.IOException;
 
 import ee.jakarta.tck.ws.rs.common.JAXRSCommonClient;
@@ -429,7 +430,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
     invoke();
     boolean foundGet = false;
     for (String header : getResponseHeaders())
-      if (header.toLowerCase().startsWith(HttpHeaders.ALLOW.toLowerCase()))
+      if (header.toLowerCase(Locale.ROOT).startsWith(HttpHeaders.ALLOW.toLowerCase(Locale.ROOT)))
         foundGet |= header.contains(Request.GET.name());
     assertTrue(foundGet, "Header Allow: GET was not found");
     logMsg("Header Allow: GET found as expected");

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java
@@ -429,7 +429,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
     invoke();
     boolean foundGet = false;
     for (String header : getResponseHeaders())
-      if (header.startsWith(HttpHeaders.ALLOW))
+      if (header.toLowerCase().startsWith(HttpHeaders.ALLOW.toLowerCase()))
         foundGet |= header.contains(Request.GET.name());
     assertTrue(foundGet, "Header Allow: GET was not found");
     logMsg("Header Allow: GET found as expected");


### PR DESCRIPTION
Resolves https://github.com/jakartaee/rest/issues/1267 by allowing "allow" and "Allow" in header text for [optionsOnSubResourceTest](https://github.com/jakartaee/rest/blob/main/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/spec/resource/requestmatching/JAXRSClientIT.java#L432)

