### PR TITLE
Fix TCK header case issue for ee.jakarta.tck.ws.rs.ee.rs.container.requestcontext.JAXRSClientIT.containsHeaderStringTest

### DIFF
--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/ee/rs/container/requestcontext/JAXRSClientIT.java
@@ -351,7 +351,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
       setProperty(Property.REQUEST_HEADERS,
               "Content-Type:application/xml;charset=utf8");
       setProperty(Property.REQUEST_HEADERS,
-              "Header3:value1 ;; Value2 ;;value 3");
+              "header3:value1 ;; Value2 ;;value 3");
       setProperty(Property.SEARCH_STRING, "Test1");
       setProperty(Property.SEARCH_STRING, "Test2");
       setProperty(Property.SEARCH_STRING, "Test3");


### PR DESCRIPTION
Fixes #1278 

Although there are a couple alternative for fixing the issue identified in #1278, simply changing the case for the Header3 header added in `containsHeaderStringTest` appears to be the simplest solution with the least amount of associated risk.

See #1278 for details.