### PR TITLE
Modernization: Replacing custom loop by ServiceLoader.findFirst()

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -174,10 +174,7 @@ final class FactoryFinder {
     private static <T> T findFirstService(final String factoryId, final ClassLoader cl, final Class<T> service) {
         final PrivilegedAction<T> action = () -> {
             try {
-                final ServiceLoader<T> loader = ServiceLoader.load(service, cl);
-                if (loader.iterator().hasNext()) {
-                    return loader.iterator().next();
-                }
+                return ServiceLoader.load(service, cl).findFirst().orElse(null);
             } catch (Exception e) {
                 LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
             }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -174,10 +174,7 @@ final class FactoryFinder {
     private static <T> T findFirstService(final String factoryId, final ClassLoader cl, final Class<T> service) {
         final PrivilegedAction<T> action = () -> {
             try {
-                final ServiceLoader<T> loader = ServiceLoader.load(service, cl);
-                if (loader.iterator().hasNext()) {
-                    return loader.iterator().next();
-                }
+                return ServiceLoader.load(service, cl).findFirst().orElse(null);
             } catch (Exception e) {
                 LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
             }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/sse/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/sse/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -174,10 +174,7 @@ final class FactoryFinder {
     private static <T> T findFirstService(final String factoryId, final ClassLoader cl, final Class<T> service) {
         final PrivilegedAction<T> action = () -> {
             try {
-                final ServiceLoader<T> loader = ServiceLoader.load(service, cl);
-                if (loader.iterator().hasNext()) {
-                    return loader.iterator().next();
-                }
+                return ServiceLoader.load(service, cl).findFirst().orElse(null);
             } catch (Exception e) {
                 LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
             }


### PR DESCRIPTION
This PR modernizes the source code by using JDK 9's `ServiceLoader.findFirst()` method instead of a custom loop.

*Requesting **fast-track** according to our Committer Conventions, as this PR is a non-API, non-spec, non-javadoc change.*