### PR TITLE
Performance: Getting rid of temporary internal StringWriter

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Variant.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Variant.java
@@ -227,14 +227,14 @@ public class Variant {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("Variant[mediaType=");
-        sb.append(mediaType);
-        sb.append(", language=");
-        sb.append(language);
-        sb.append(", encoding=");
-        sb.append(encoding);
-        sb.append(']');
-        return sb.toString();
+        return new StringBuilder("Variant[mediaType=")
+                .append(mediaType)
+                .append(", language=")
+                .append(language)
+                .append(", encoding=")
+                .append(encoding)
+                .append(']')
+                .toString();
     }
 
     /**

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Variant.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Variant.java
@@ -16,7 +16,6 @@
 
 package jakarta.ws.rs.core;
 
-import java.io.StringWriter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -228,15 +227,14 @@ public class Variant {
 
     @Override
     public String toString() {
-        StringWriter w = new StringWriter();
-        w.append("Variant[mediaType=");
-        w.append(mediaType == null ? "null" : mediaType.toString());
-        w.append(", language=");
-        w.append(language == null ? "null" : language.toString());
-        w.append(", encoding=");
-        w.append(encoding == null ? "null" : encoding);
-        w.append("]");
-        return w.toString();
+        StringBuilder sb = new StringBuilder("Variant[mediaType=");
+        sb.append(mediaType);
+        sb.append(", language=");
+        sb.append(language);
+        sb.append(", encoding=");
+        sb.append(encoding);
+        sb.append(']');
+        return sb.toString();
     }
 
     /**

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Variant.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Variant.java
@@ -227,14 +227,13 @@ public class Variant {
 
     @Override
     public String toString() {
-        return new StringBuilder("Variant[mediaType=")
-                .append(mediaType)
-                .append(", language=")
-                .append(language)
-                .append(", encoding=")
-                .append(encoding)
-                .append(']')
-                .toString();
+        return "Variant[mediaType="
+                + mediaType
+                + ", language="
+                + language
+                + ", encoding="
+                + encoding
+                + ']';
     }
 
     /**


### PR DESCRIPTION
TL;DR: This PR internally optimizes the JAX-RS API implementation code by getting rid of `StringWriter` for *purely temporary* use case.

*Requesting **fast-track** according to our Committer Conventions, as this PR is a non-API, non-spec, non-javadoc change.*

For those interested in the details:
* `StringWriter` is implicitly synchronized due to its internal use of `StringBuffer`, while `StringBuilder` is non-synchronized. Using synchronized code in single-threaded contexts is not needed.
* Providing initial content to the constructor reduces number of interally copied bytes on later `append` thanks to bigger upfront buffer allocation.
* Appending `null` automatically appends `"null"`. This is implied by `StringBuilder`, no need for custom code.
* Appending a single `char` is faster than adding a single-character `String`.
* `StringBuilder` has fluent API; no need to repeat `sb` again and again.
* Since long time (JDK 8 and earlier), `String +` operation *implies* creation of `StringBuilder`, and is proven to be *always* faster than an *explicit* `StringBuilder` (see [Video "String Concatenation - JEP Café #7"](https://www.youtube.com/watch?v=w56RUzBLaRE) for the benchmark results).
* Since [JEP 280](https://openjdk.org/jeps/280) (JDK 9), `String +` operator is indified, leading to higher performance in future, just by upgrading JRE.
