### PR TITLE
New method MediaType.getCharsetParameter() returns charset instance or null

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/MediaType.java
@@ -16,6 +16,8 @@
 
 package jakarta.ws.rs.core;
 
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -304,6 +306,19 @@ public class MediaType {
      */
     public Map<String, String> getParameters() {
         return parameters;
+    }
+
+    /**
+     * Getter for the media type {@code charset} parameter value.
+     *
+     * @return charset built from the {@value #CHARSET_PARAMETER} parameter value. {@code null} if the parameter
+     * is {@code null}, empty or blank.
+     * @throws UnsupportedCharsetException if the charset from the {@value #CHARSET_PARAMETER} parameter value
+     * is not supported.
+     */
+    public Charset getCharsetParameter() throws UnsupportedCharsetException {
+        final var charset = parameters.get(CHARSET_PARAMETER);
+        return charset == null || charset.isEmpty() ? null : Charset.forName(charset);
     }
 
     /**

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/MediaTypeTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/MediaTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,12 +19,16 @@ package jakarta.ws.rs.core;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 
 /**
@@ -33,6 +37,22 @@ import java.util.Map;
  * @author Marek Potociar
  */
 public class MediaTypeTest {
+
+    /**
+     * Test {@link MediaType#getCharsetParameter()} method.
+     */
+    @Test
+    public void testGetCharsetParameter() {
+        assertEquals(StandardCharsets.UTF_8,
+                MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8")
+                        .getCharsetParameter(),
+                "Unexpected produced media type charset parameter.");
+        try {
+            MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8").withCharset("unsupported-charset")
+                    .getCharsetParameter();
+            fail("Unexpected produced media type charset parameter.");
+        } catch (final UnsupportedCharsetException expectedException) {}
+    }
 
     /**
      * Test {@link MediaType#withCharset(String)} method.


### PR DESCRIPTION
# Proposal
I like to propose the addition of the new method `MediaType.getCharsetParameter()` which either returns a `Charset` instance, `null`, or throws `UnsupportedCharsetException`.

# Justification
Rather often I came across code like the following lines (quoted from Jersey) in applications, filters and compliant implementations:

https://github.com/eclipse-ee4j/jersey/blob/b128e9c9e649e96488a9c1d367e4cbae89a9d1d4/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java#L127-L130
```java
public static Charset getCharset(MediaType m) {
    String name = (m == null) ? null : m.getParameters().get(MediaType.CHARSET_PARAMETER);
    return (name == null) ? StandardCharsets.UTF_8 : Charset.forName(name);
}
```
I do not see any benefit in repeating the obvious again and again, so why not giving away this standard solution for free as part of JAX-RS itself? 😃 