### PR TITLE
Remove SecurityManager related code from API

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientBuilder.java
@@ -19,9 +19,7 @@ package jakarta.ws.rs.client;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.net.URL;
-import java.security.AccessController;
 import java.security.KeyStore;
-import java.security.PrivilegedAction;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -61,13 +59,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
         try {
             Object delegate = FactoryFinder.find(JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY, ClientBuilder.class);
             if (!(delegate instanceof ClientBuilder)) {
-                final CreateErrorMessageAction action = new CreateErrorMessageAction(delegate);
-                final String errorMessage;
-                if (System.getSecurityManager() == null) {
-                    errorMessage = action.run();
-                } else {
-                    errorMessage = AccessController.doPrivileged(action);
-                }
+                final String errorMessage = getCreateErrorMessage(delegate);
                 throw new LinkageError(errorMessage);
             }
             return (ClientBuilder) delegate;
@@ -272,25 +264,16 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      */
     public abstract Client build();
 
-    private static final class CreateErrorMessageAction implements PrivilegedAction<String> {
-        private final Object delegate;
-
-        private CreateErrorMessageAction(final Object delegate) {
-            this.delegate = delegate;
+    private static String getCreateErrorMessage(Object delegate) {
+        Class<?> pClass = ClientBuilder.class;
+        String classnameAsResource = pClass.getName().replace('.', '/') + ".class";
+        ClassLoader loader = pClass.getClassLoader();
+        if (loader == null) {
+            loader = ClassLoader.getSystemClassLoader();
         }
-
-        @Override
-        public String run() {
-            Class<?> pClass = ClientBuilder.class;
-            String classnameAsResource = pClass.getName().replace('.', '/') + ".class";
-            ClassLoader loader = pClass.getClassLoader();
-            if (loader == null) {
-                loader = ClassLoader.getSystemClassLoader();
-            }
-            URL targetTypeURL = loader.getResource(classnameAsResource);
-            return "ClassCastException: attempting to cast"
-                    + delegate.getClass().getClassLoader().getResource(classnameAsResource)
-                    + " to " + targetTypeURL;
-        }
+        URL targetTypeURL = loader.getResource(classnameAsResource);
+        return "ClassCastException: attempting to cast"
+                + delegate.getClass().getClassLoader().getResource(classnameAsResource)
+                + " to " + targetTypeURL;
     }
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/FactoryFinder.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -41,26 +39,6 @@ final class FactoryFinder {
 
     private FactoryFinder() {
         // prevents instantiation
-    }
-
-    private static ClassLoader getContextClassLoader() {
-        // For performance reasons, check if a security manager is installed. If not there is no need to use a
-        // privileged action.
-        if (System.getSecurityManager() == null) {
-            return Thread.currentThread().getContextClassLoader();
-        }
-        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
-            ClassLoader cl = null;
-            try {
-                cl = Thread.currentThread().getContextClassLoader();
-            } catch (SecurityException ex) {
-                LOGGER.log(
-                        Level.WARNING,
-                        "Unable to get context classloader instance.",
-                        ex);
-            }
-            return cl;
-        });
     }
 
     /**
@@ -109,7 +87,7 @@ final class FactoryFinder {
      * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     static <T> Object find(final String factoryId, final Class<T> service) throws ClassNotFoundException {
-        ClassLoader classLoader = getContextClassLoader();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
         // First try the TCCL
         Object result = findFirstService(factoryId, classLoader, service);
@@ -118,7 +96,7 @@ final class FactoryFinder {
         }
 
         // Next try the class loader from the FactoryFinder
-        result = findFirstService(factoryId, getClassLoader(), service);
+        result = findFirstService(factoryId, FactoryFinder.class.getClassLoader(), service);
         if (result != null) {
             return result;
         }
@@ -164,25 +142,12 @@ final class FactoryFinder {
                 "Provider for " + factoryId + " cannot be found", null);
     }
 
-    private static ClassLoader getClassLoader() {
-        if (System.getSecurityManager() == null) {
-            return FactoryFinder.class.getClassLoader();
-        }
-        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) FactoryFinder.class::getClassLoader);
-    }
-
     private static <T> T findFirstService(final String factoryId, final ClassLoader cl, final Class<T> service) {
-        final PrivilegedAction<T> action = () -> {
-            try {
-                return ServiceLoader.load(service, cl).findFirst().orElse(null);
-            } catch (Exception e) {
-                LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
-            }
-            return null;
-        };
-        if (System.getSecurityManager() == null) {
-            return action.run();
+        try {
+            return ServiceLoader.load(service, cl).findFirst().orElse(null);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
         }
-        return AccessController.doPrivileged(action);
+        return null;
     }
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/RuntimeDelegate.java
@@ -16,7 +16,6 @@
 
 package jakarta.ws.rs.ext;
 
-import java.lang.reflect.ReflectPermission;
 import java.net.URL;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.locks.Lock;
@@ -48,7 +47,6 @@ public abstract class RuntimeDelegate {
      */
     public static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "jakarta.ws.rs.ext.RuntimeDelegate";
     private static final Lock RD_LOCK = new ReentrantLock();
-    private static ReflectPermission suppressAccessChecksPermission = new ReflectPermission("suppressAccessChecks");
     private static volatile RuntimeDelegate cachedDelegate;
 
     /**
@@ -129,14 +127,8 @@ public abstract class RuntimeDelegate {
      * {@link #getInstance} then an implementation will be sought as described in {@link #getInstance}.
      *
      * @param rd the runtime delegate instance
-     * @throws SecurityException if there is a security manager and the permission ReflectPermission("suppressAccessChecks")
-     * has not been granted.
      */
     public static void setInstance(final RuntimeDelegate rd) {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(suppressAccessChecksPermission);
-        }
         RD_LOCK.lock();
         try {
             RuntimeDelegate.cachedDelegate = rd;

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/sse/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/sse/FactoryFinder.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -41,26 +39,6 @@ final class FactoryFinder {
 
     private FactoryFinder() {
         // prevents instantiation
-    }
-
-    private static ClassLoader getContextClassLoader() {
-        // For performance reasons, check if a security manager is installed. If not there is no need to use a
-        // privileged action.
-        if (System.getSecurityManager() == null) {
-            return Thread.currentThread().getContextClassLoader();
-        }
-        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
-            ClassLoader cl = null;
-            try {
-                cl = Thread.currentThread().getContextClassLoader();
-            } catch (SecurityException ex) {
-                LOGGER.log(
-                        Level.WARNING,
-                        "Unable to get context classloader instance.",
-                        ex);
-            }
-            return cl;
-        });
     }
 
     /**
@@ -109,7 +87,7 @@ final class FactoryFinder {
      * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     static <T> Object find(final String factoryId, final Class<T> service) throws ClassNotFoundException {
-        ClassLoader classLoader = getContextClassLoader();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
         // First try the TCCL
         Object result = findFirstService(factoryId, classLoader, service);
@@ -118,7 +96,7 @@ final class FactoryFinder {
         }
 
         // Next try the class loader from the FactoryFinder
-        result = findFirstService(factoryId, getClassLoader(), service);
+        result = findFirstService(factoryId, FactoryFinder.class.getClassLoader(), service);
         if (result != null) {
             return result;
         }
@@ -164,25 +142,12 @@ final class FactoryFinder {
                 "Provider for " + factoryId + " cannot be found", null);
     }
 
-    private static ClassLoader getClassLoader() {
-        if (System.getSecurityManager() == null) {
-            return FactoryFinder.class.getClassLoader();
-        }
-        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) FactoryFinder.class::getClassLoader);
-    }
-
     private static <T> T findFirstService(final String factoryId, final ClassLoader cl, final Class<T> service) {
-        final PrivilegedAction<T> action = () -> {
-            try {
-                return ServiceLoader.load(service, cl).findFirst().orElse(null);
-            } catch (Exception e) {
-                LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
-            }
-            return null;
-        };
-        if (System.getSecurityManager() == null) {
-            return action.run();
+        try {
+            return ServiceLoader.load(service, cl).findFirst().orElse(null);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINER, "Failed to load service " + factoryId + ".", e);
         }
-        return AccessController.doPrivileged(action);
+        return null;
     }
 }


### PR DESCRIPTION
For Jakarta EE 12, the plan is to update all APIs to remove references to the SecurityManager and related APIs in preparation for Java SE 29 which may remove the API or not allow it to be run.

Fixes #1262 