### PR TITLE
 #1304 add missing osgi capability info for spifly injection (main)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,14 @@
                             <specversion>${spec.version}</specversion>
                             <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                             <_nodefaultversion>false</_nodefaultversion>
-                            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
+                            <!-- Needed to integrate ServiceLoader mechanism with OSGi -->
+                            <Require-Capability><![CDATA[
+                            osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))",
+                            osgi.serviceloader;filter:="(osgi.serviceloader=jakarta.ws.rs.ext.RuntimeDelegate)";osgi.serviceloader="jakarta.ws.rs.ext.RuntimeDelegate",
+                            osgi.serviceloader;filter:="(osgi.serviceloader=jakarta.ws.rs.client.ClientBuilder)";osgi.serviceloader="jakarta.ws.rs.client.ClientBuilder",
+                            osgi.serviceloader;filter:="(osgi.serviceloader=jakarta.ws.rs.sse.SseEventSource.Builder)";osgi.serviceloader="jakarta.ws.rs.sse.SseEventSource.Builder",
+                            osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+                            ]]></Require-Capability>
                         </instructions>
                     </configuration>
                     <executions>


### PR DESCRIPTION
See #1304

According to https://docs.osgi.org/specification/osgi.enterprise/7.0.0/service.loader.html#d0e60965

The `processor` entry:

Consumers are classes that use the Service Loader API to find Service Provider instances. Since the Service Loader API requires full visibility the Service API fails to work inside an OSGi bundle. A osgi.serviceloader.processor extender, which is the Mediator, processes bundles that require this capability by modifying calls to the Service Loader API to ensures that the Service Loader has visibility to published Service Providers. 

So this is a **Client** that opts for injection of `jakarta.ws.rs.ext.RuntimeDelegate`, `jakarta.ws.rs.client.ClientBuilder` and `jakarta.ws.rs.sse.SseEventSource.Builder`